### PR TITLE
Pin more specific version of Celery to resolve version conflict with …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 dist: trusty
 language: python
+python: 2.7 
 services:
 - docker
 - postgresql

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'gipc>=0.6.0, <0.7.0',
         'unicodecsv>=0.14.1, < 0.15.0',
         'shapely',
-        'celery[redis]>=4.0, <5.0',
+        'celery[redis]>=4.0, <4.3',
         'boto>=2.39.0, <3.0.0',
         'fiona',
         'python-magic>=0.4.11, <=0.5.0',

--- a/tests/idb/test_data_api_media.py
+++ b/tests/idb/test_data_api_media.py
@@ -77,7 +77,7 @@ def test_render_svg(client, mock):
     url = url_for('idb.data_api.v2_media.lookup_uuid', u="872733a2-67a3-4c54-aa76-862735a5f334", deriv="thumbnail")
     r = client.get(url)
     assert r.status_code == 200
-    assert r.content_type == "image/svg+xml"
+    assert r.content_type == "image/svg+xml; charset=utf-8"
 
 
 @pytest.mark.readonly


### PR DESCRIPTION
…py-redis

Version 4.3 of Celery bumped minimum version of py-redis to 3.2.0. idb-backend currently has v2.x specified and would cause any calls into the main idb command to fail with runtime errors.