### PR TITLE
psycopg2 package deprecated by upstream in favor of psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     setup_requires=['pytest-runner'],
     install_requires=[
         'idigbio>=0.8.2',
-        'psycopg2>=2.6',
+        'psycopg2-binary>=2.8.3',
         'redis>=2.9.1, <3.0.0',
         'python-dateutil>=2.2, <3.0',
         'udatetime>=0.0.13',


### PR DESCRIPTION
See http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/