### PR TITLE
fix various issues with recordids in publisher feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv/
+.virtualenv/
 
 # Spyder project settings
 .spyderproject

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -314,7 +314,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
                         recordset["id"], recordset["uuid"], file_link, rs_name)
 
 
-    db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID)
+    db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID),
                   {
                       "rss_url": r["rss_url"],
                       "name": name,

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -70,6 +70,7 @@ def get_feed(rss_url):
         from the URI, otherwise return False.
 
     """
+
     feedtest = None
     try:
         feedtest = requests.get(rss_url, timeout=10)
@@ -142,6 +143,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
     existing_recordsets : set
         Set of existing known recordset uuids
     """
+
     logger.debug("Start parsing results of %s, length: %s", r['rss_url'], len(rsscontents))
     feed = feedparser.parse(rsscontents)
     pub_uuid = r["uuid"]

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -127,12 +127,16 @@ def get_feed(rss_url):
 
 
 def update_db_from_rss():
+    # existing_recordsets is a SET that will hold db ids (not uuids or recordids)
     existing_recordsets = {}
     recordsets = {}
     with PostgresDB() as db:
         for r in db.fetchall("SELECT * FROM recordsets"):
             for recordid in r["recordids"]:
+                logger.debug("recordid | id : '{0}' | '{1}'.format(recordid, r["id"])")
                 existing_recordsets[recordid] = r["id"]
+            # I believe the bug for Redmine #3124 is multiple ids are added to the set, but by definition
+            # the set only keeps one of them. 
             recordsets[r["id"]] = r
         #logger.debug("***existing_recordsets DUMP ***\n")
         #logger.debug("{0}".format(existing_recordsets))

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -168,7 +168,7 @@ def update_db_from_rss():
             rsscontents = get_feed(rss_url)
             if rsscontents:
                 try:
-                    _do_rss(rsscontents, row, db, recordsets, existing_recordsets)
+                    _do_rss(rsscontents, row, db, recordsets, existing_recordsets, file_links)
                     logger.debug('_do_rss returned, ready to COMMIT...')
                     db.commit()
                 except Exception:
@@ -312,7 +312,7 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
                     recordset["id"], recordset["uuid"], file_link, rs_name)
 
 
-def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
+def _do_rss(rsscontents, r, db, recordsets, existing_recordsets, file_links):
     """
     Process one RSS feed contents.  Compares the recordsets we know
     about with the ones found in the feed.
@@ -330,6 +330,8 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
         dict of existing known recordset db ids with associated db row data
     existing_recordsets : dict
         dict of existing known recordset recordids with associated db ids
+    file_links : dict
+        dict of existing know file_links with associated db ids
     """
 
     logger.debug("Start parsing results of %s", r['rss_url'])

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -272,7 +272,10 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
         logger.info("Created Recordset for recordid:%s '%s'", recordid, rs_name)
     else:
         logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}'".format(recordset["id"], feed_recordids, file_link))
-
+        if file_link != recordsets["id"]["file_link"]:
+            logger.debug("file_link '{0}' found does not match expected '{1}' based on DB id '{2}'".format(
+                file_link, recordsets["id"]["file_link"],  recordset["id"]
+            ))
         logger.debug("Existing DB id for this recordid: '{0}'".format(existing_recordsets[recordid]))
         logger.debug("Expected DB id to update: '{0}'".format(recordset["id"]))
         if existing_recordsets[recordid] != recordset["id"]:

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -34,7 +34,7 @@ IDIGBIO_ROOT_UUID = "872733a2-67a3-4c54-aa76-862735a5f334"
 
 logger = idblogger.getChild('upr')
 
-def EARLY_EXIT(msg):
+def EARLY_EXIT(msg=''):
     raise SystemExit("EARLY EXIT  " + msg)
 
 def struct_to_datetime(s):

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -55,8 +55,8 @@ def struct_to_datetime(s):
 
 def id_func(portal_url, e):
     """
-    Given a portal url and a feedparser RSS dictionary,
-    return something suitable to be used as a recordid.
+    Given a portal url and an RSS feed entry (feedparser dictionary
+    object), return something suitable to be used as a recordid.
 
     Parameters
     ----------
@@ -67,7 +67,7 @@ def id_func(portal_url, e):
     """
 
     id = None
-    if "id" in e:   # feedparser magic maps various fields to "id"
+    if "id" in e:   # feedparser magic maps various fields to "id" including "guid"
         id = e["id"]
     elif "collid" in e:
         id = "{0}collections/misc/collprofiles.php?collid={1}".format(
@@ -231,8 +231,9 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
 
     logger.debug("Begin iteration over entries found in '{0}'".format(r['rss_url']))
     for e in feed['entries']:
+        # why is the portal_url and not something like file_link ?
         recordid = id_func(r['portal_url'], e)
-        logger.debug ("id_func returned '{0}'".format(recordid))
+        logger.debug ("id_func returned recorid '{0}' from portal url '{1}'".format(recordid, r['portal_url']))
         rsid = None
         ingest = auto_publish
         recordids = [recordid]
@@ -243,7 +244,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
             logger.debug("recordset = '{0}'".format(recordset))
             rsid = recordset["uuid"]
             ingest = recordset["ingest"]
-            recordids = list(set(recordids + recordset["recordids"])) # is this set dropping important info
+            recordids = list(set(recordids + recordset["recordids"])) # is this set dropping important info?
         else:
             logger.debug("recordid '{0}' NOT found in existing recordsets.".format(recordid))
 

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -286,8 +286,8 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
         # The DB id should match when doing a "reverse" look up by file_link.
         if file_link in file_links:
             if recordset["id"] != file_links[file_link]:
-                logger.error("Skipping file_link: '{3}'. Found conflict or duplicate recordid. "
-                             "Investigate db ids: '{0}' and '{1}'".format(
+                logger.error("Skipping file_link: '{0}'. Found conflict or duplicate recordid."
+                             "Investigate db ids: '{1}' and '{2}'".format(
                     recordset["id"], file_links[file_link], file_link
                 ))
                 return

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -251,7 +251,7 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets):
         logger.debug("No recordid identified.")
 
     if recordset is None:
-        logger.debug("Ready to INSERT: '{0}', '{1}', '{2}'".format(recordids, rs_name, file_link))
+        logger.debug("Ready to INSERT: '{0}', '{1}'".format(recordids, file_link))
         sql = (
             """INSERT INTO recordsets
                  (uuid, publisher_uuid, name, recordids, eml_link, file_link, ingest, pub_date)
@@ -263,7 +263,7 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets):
         db.execute(*sql)
         logger.info("Created Recordset for recordid:%s '%s'", recordid, rs_name)
     else:
-        logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}'".format(recordids, rs_name, file_link))
+        logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}'".format(recordset["id"], recordids, file_link))
         sql = ("""UPDATE recordsets
                   SET publisher_uuid=%(publisher_uuid)s,
                       eml_link=%(eml_link)s,

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -127,22 +127,24 @@ def get_feed(rss_url):
 
 
 def update_db_from_rss():
-    # existing_recordsets is a SET that will hold db ids (not uuids or recordids)
+    # existing_recordsets is a dict that will hold rows base on recordids
     existing_recordsets = {}
+    # recordsets is a dict that will hold rows based on db id (not recordid or uuid)
     recordsets = {}
     with PostgresDB() as db:
+        logger.debug("Gathering existing recordsets...")
         for row in db.fetchall("SELECT * FROM recordsets"):
             for recordid in row["recordids"]:
                 logger.debug("id | recordid | file_link: '{0}' | '{1}' | '{2}'".format(
                     row["id"], recordid, row["file_link"]))
                 if recordid in existing_recordsets:
-                    logger.error("Found a duplicate recordid. This recordid = '{0}'"
-                        ". Other row = {1}".format(recordid, existing_recordsets[recordid]))
+                    logger.error("Found a duplicate recordid in existing recordsets. This should never happen.")
+                    logger.error("This recordid = '{0}'"
+                        ". Other row = ''{1}''".format(recordid, existing_recordsets[recordid]))
                 else:
                     existing_recordsets[recordid] = row["id"]
             recordsets[row["id"]] = row
-        #logger.debug("***existing_recordsets DUMP ***\n")
-        #logger.debug("{0}".format(existing_recordsets))
+        logger.debug("Gathering existing publishers...")
         pub_recs = db.fetchall("SELECT * FROM publishers")
         logger.debug("Checking %d publishers", len(pub_recs))
         for row in pub_recs:

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -306,8 +306,9 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
         dict of existing known recordset recordids with associated db ids
     """
 
-    logger.debug("Start parsing results of %s, length: %s", r['rss_url'], len(rsscontents))
+    logger.debug("Start parsing results of %s", r['rss_url'])
     feed = feedparser.parse(rsscontents)
+    logger.debug("Found {0} entries in feed to process.".format(len(feed)))
     pub_uuid = r["uuid"]
     if pub_uuid is None:
         pub_uuid, _, _ = db.get_uuid(r["recordids"])

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -217,7 +217,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
            })
     db.execute(*sql)
 
-    logger.debug("Begin iteration over entries found in '{0}'".format(r['rss_url'])
+    logger.debug("Begin iteration over entries found in '{0}'".format(r['rss_url']))
     for e in feed['entries']:
         logger.debug ("'e' in feed is of type {0}".format(type(e)))
         recordid = id_func(r['portal_url'], e)

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -251,7 +251,7 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets):
         logger.debug("No recordid identified.")
 
     if recordset is None:
-        logger.debug("Ready to INSERT: '{0}', '{1}', '{2}'".format(recordids, name, file_link))
+        logger.debug("Ready to INSERT: '{0}', '{1}', '{2}'".format(recordids, rs_name, file_link))
         sql = (
             """INSERT INTO recordsets
                  (uuid, publisher_uuid, name, recordids, eml_link, file_link, ingest, pub_date)
@@ -263,7 +263,7 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets):
         db.execute(*sql)
         logger.info("Created Recordset for recordid:%s '%s'", recordid, rs_name)
     else:
-        logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}'".format(recordids, name, file_link))
+        logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}'".format(recordids, rs_name, file_link))
         sql = ("""UPDATE recordsets
                   SET publisher_uuid=%(publisher_uuid)s,
                       eml_link=%(eml_link)s,

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -144,7 +144,7 @@ def update_db_from_rss():
                 else:
                     existing_recordsets[recordid] = row["id"]
             recordsets[row["id"]] = row
-        for
+
         logger.debug("Gathering existing publishers...")
         pub_recs = db.fetchall("SELECT * FROM publishers")
         logger.debug("Checking %d publishers", len(pub_recs))

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -304,7 +304,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
             logger.debug("No recordid identified.")
 
         if recordset is None:
-            logger.debug("Ready to INSERT: '{0}', '{1}', '{2}'".format(name, recordids, file_link))
+            logger.debug("Ready to INSERT: '{0}', '{1}', '{2}'".format(recordids, name, file_link))
             sql = (
                 """INSERT INTO recordsets
                      (uuid, publisher_uuid, name, recordids, eml_link, file_link, ingest, pub_date)
@@ -316,7 +316,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
             db.execute(*sql)
             logger.info("Created Recordset for recordid:%s '%s'", recordid, rs_name)
         else:
-            logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}', '{3}'".format(uuid, name, recordids, file_link))
+            logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}'".format(recordids, name, file_link))
             sql = ("""UPDATE recordsets
                       SET publisher_uuid=%(publisher_uuid)s,
                           eml_link=%(eml_link)s,

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -135,10 +135,9 @@ def update_db_from_rss():
             for recordid in row["recordids"]:
                 logger.debug("recordid | id : '{0}' | '{1}'".format(recordid, row["id"]))
 # sample loglines, '1162234d-4e06-4d63-8a49-034184a38c7e' maps to multiple db ids
-#2019-06-30 22:24:46.456 DEBUG idb.upr჻ recordid | id : '1162234d-4e06-4d63-8a49-034184a38c7e' | '4246'
-#2019-06-30 22:24:46.456 DEBUG idb.upr჻ recordid | id : 'http://ipt.idigbio.org/resource?id=uprm-invcol' | '4246'
-#2019-06-30 22:24:47.108 DEBUG idb.upr჻ recordid | id : 'ff3f430a-ca02-46ed-81b5-7c53c17f4041' | '12681'
-#2019-06-30 22:24:47.108 DEBUG idb.upr჻ recordid | id : '1162234d-4e06-4d63-8a49-034184a38c7e' | '12681'
+#2019-06-30 22:24:46.456 DEBUG idb.upr:- recordid | id : '1162234d-4e06-4d63-8a49-034184a38c7e' | '4246'
+#2019-06-30 22:24:46.456 DEBUG idb.upr:- recordid | id : 'http://ipt.idigbio.org/resource?id=uprm-invcol' | '4246'
+#2019-06-30 22:24:47.108 DEBUG idb.upr:- recordid | id : '1162234d-4e06-4d63-8a49-034184a38c7e' | '12681'
                 existing_recordsets[recordid] = row["id"]
             recordsets[row["id"]] = row
         #logger.debug("***existing_recordsets DUMP ***\n")

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -127,7 +127,7 @@ def get_feed(rss_url):
 
 
 def update_db_from_rss():
-    # existing_recordsets is a dict that will hold rows base on recordids
+    # existing_recordsets is a dict that will hold mapping of recordids to db id
     existing_recordsets = {}
     # recordsets is a dict that will hold rows based on db id (not recordid or uuid)
     recordsets = {}
@@ -144,6 +144,7 @@ def update_db_from_rss():
                 else:
                     existing_recordsets[recordid] = row["id"]
             recordsets[row["id"]] = row
+        for
         logger.debug("Gathering existing publishers...")
         pub_recs = db.fetchall("SELECT * FROM publishers")
         logger.debug("Checking %d publishers", len(pub_recs))
@@ -179,9 +180,9 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
     db : database object
         A PostgresDB() database object
     recordsets : set
-        Set object to maintain list of recordsets found in the RSS feed
-    existing_recordsets : set
-        Set of existing known recordset uuids
+        dict of existing known recordset db ids with associated db row data
+    existing_recordsets : dict
+        dict of existing known recordset recordids with associated db ids
     """
 
     logger.debug("Start parsing results of %s, length: %s", r['rss_url'], len(rsscontents))
@@ -239,9 +240,10 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
         if recordid in existing_recordsets:
             logger.debug("Found recordid '{0}' in existing recordsets.".format(recordid))
             recordset = recordsets[existing_recordsets[recordid]]
+            logger.debug("recordset = '{0}'".format(recordset))
             rsid = recordset["uuid"]
             ingest = recordset["ingest"]
-            recordids = list(set(recordids + recordset["recordids"]))
+            recordids = list(set(recordids + recordset["recordids"])) # is this set dropping important info
         else:
             logger.debug("recordid '{0}' NOT found in existing recordsets.".format(recordid))
 
@@ -289,6 +291,8 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
             logger.debug("Identified recordid:  '{0}'".format(recordid))
         else:
             logger.debug("No recordid identified.")
+
+
 
         if recordset is None:
             sql = (

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -175,7 +175,7 @@ def update_db_from_rss():
                     raise
     logger.info("Finished processing add publisher RSS feeds")
 
-def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets):
+def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uuid):
     """
     Do the recordset parts.
 
@@ -354,7 +354,8 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
     logger.debug("Begin iteration over entries found in '{0}'".format(r['rss_url']))
     for e in feed['entries']:
         _do_rss_entry(e, r['portal_url'], db, recordsets,
-                      existing_recordsets) # (feedparser object, row of pub data, db object)
+                      existing_recordsets,
+                      pub_uuid) # (feedparser object, row of pub data, db object)
 
     EARLY_EXIT("before set_record on pub_uuid")
 

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -32,6 +32,21 @@ from idigbio_ingestion.lib.eml import parseEml
 logger = idblogger.getChild('upr')
 
 def struct_to_datetime(s):
+    """
+    Convert a Struct representation of a time to a datetime
+    timestamp.
+
+    Parameters
+    ----------
+    s : struct
+        Timestamp in Struct representation, a 9-tuple such as
+        (2019, 2, 17, 17, 3, 38, 1, 48, 0)
+
+    Returns
+    -------
+    datetime timestamp
+    """
+
     return datetime.datetime.fromtimestamp(time.mktime(s))
 
 
@@ -135,7 +150,8 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
     rsscontents : text
         Content of an RSS feed
     r : row of publisher data
-        A row of data from the publishers table that contains all columns
+        A row of data from the publishers table that contains all columns,
+        each column addressable as r["column_name"]
     db : database object
         A PostgresDB() database object
     recordsets : set
@@ -242,6 +258,11 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
             rs_name = recordset["name"]
         else:
             rs_name = recordid
+
+        if recordid is not None:
+            logger.debug("Identified recordid:  '{0}'".format(recordid))
+        else:
+            logger.debug("No recordid identified.")
 
         if recordset is None:
             sql = (

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -131,23 +131,27 @@ def update_db_from_rss():
     existing_recordsets = {}
     recordsets = {}
     with PostgresDB() as db:
-        for r in db.fetchall("SELECT * FROM recordsets"):
-            for recordid in r["recordids"]:
-                logger.debug("recordid | id : '{0}' | '{1}'".format(recordid, r["id"]))
-                existing_recordsets[recordid] = r["id"]
-            # BZZZZP
-            recordsets[r["id"]] = r
+        for row in db.fetchall("SELECT * FROM recordsets"):
+            for recordid in row["recordids"]:
+                logger.debug("recordid | id : '{0}' | '{1}'".format(recordid, row["id"]))
+# sample loglines, '1162234d-4e06-4d63-8a49-034184a38c7e' maps to multiple db ids
+#2019-06-30 22:24:46.456 DEBUG idb.upr჻ recordid | id : '1162234d-4e06-4d63-8a49-034184a38c7e' | '4246'
+#2019-06-30 22:24:46.456 DEBUG idb.upr჻ recordid | id : 'http://ipt.idigbio.org/resource?id=uprm-invcol' | '4246'
+#2019-06-30 22:24:47.108 DEBUG idb.upr჻ recordid | id : 'ff3f430a-ca02-46ed-81b5-7c53c17f4041' | '12681'
+#2019-06-30 22:24:47.108 DEBUG idb.upr჻ recordid | id : '1162234d-4e06-4d63-8a49-034184a38c7e' | '12681'
+                existing_recordsets[recordid] = row["id"]
+            recordsets[row["id"]] = row
         #logger.debug("***existing_recordsets DUMP ***\n")
         #logger.debug("{0}".format(existing_recordsets))
         pub_recs = db.fetchall("SELECT * FROM publishers")
         logger.debug("Checking %d publishers", len(pub_recs))
-        for r in pub_recs:
-            uuid, rss_url = r['uuid'], r['rss_url']
+        for row in pub_recs:
+            uuid, rss_url = row['uuid'], row['rss_url']
             logger.info("Starting Publisher Feed: %s %s", uuid, rss_url)
             rsscontents = get_feed(rss_url)
             if rsscontents:
                 try:
-                    _do_rss(rsscontents, r, db, recordsets, existing_recordsets)
+                    _do_rss(rsscontents, row, db, recordsets, existing_recordsets)
                     db.commit()
                 except Exception:
                     logger.exception("Error with %s %s", uuid, rss_url)

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -314,7 +314,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
                         recordset["id"], recordset["uuid"], file_link, rs_name)
 
 
-    db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID),
+    db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID,
                   {
                       "rss_url": r["rss_url"],
                       "name": name,

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -34,9 +34,6 @@ IDIGBIO_ROOT_UUID = "872733a2-67a3-4c54-aa76-862735a5f334"
 
 logger = idblogger.getChild('upr')
 
-def EARLY_EXIT(msg=''):
-    raise SystemExit("EARLY EXIT  " + msg)
-
 def struct_to_datetime(s):
     """
     Convert a Struct representation of a time to a datetime
@@ -401,8 +398,6 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets, file_links):
 
 
 def harvest_all_eml():
-    EARLY_EXIT('harvest')
-
     sql = """SELECT *
              FROM recordsets
              WHERE eml_link IS NOT NULL
@@ -424,8 +419,6 @@ def harvest_all_eml():
                 logger.exception("failed Harvest EML %s %s", r["id"], r["name"])
 
 def harvest_eml(r, db):
-    EARLY_EXIT('harvest')
-
     logger.info("Harvest EML %s '%s' @ '%s'", r["id"], r["name"], r["eml_link"])
     fname = "{0}.eml".format(r["id"])
     if not download_file(r["eml_link"], fname):
@@ -458,8 +451,6 @@ def harvest_eml(r, db):
 
 
 def harvest_all_file():
-    EARLY_EXIT("before harvest")
-
     sql = """SELECT *
              FROM recordsets
              WHERE file_link IS NOT NULL
@@ -483,7 +474,6 @@ def harvest_all_file():
                 db.rollback()
 
 def harvest_file(r, db):
-    EARLY_EXIT('harvest_file')
     logger.info("Harvest File %s '%s' @ '%s'", r["id"], r["name"], r["file_link"])
     fname = "{0}.file".format(r["id"])
 
@@ -504,8 +494,6 @@ def harvest_file(r, db):
 
 
 def upload_recordset(rsid, fname, idbmodel):
-    EARLY_EXIT('upload_recordset')
-
     filereference = "http://api.idigbio.org/v1/recordsets/" + rsid
     logger.debug("Starting Upload of %r", rsid)
     stor = IDigBioStorage()

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -34,47 +34,6 @@ logger = idblogger.getChild('upr')
 def struct_to_datetime(s):
     return datetime.datetime.fromtimestamp(time.mktime(s))
 
-def create_tables():
-    """
-    This function is out-of-sync with actual database, unmaintained.
-    Commenting out all action in this function, it will do nothing until modified again.
-    """
-
-    db = PostgresDB()
-    logger.error('create_tables called but has no valid code to run.')
-
-    # db.execute("""CREATE TABLE IF NOT EXISTS publishers (
-    #     id BIGSERIAL NOT NULL PRIMARY KEY,
-    #     uuid uuid UNIQUE,
-    #     name text NOT NULL,
-    #     recordids text[] NOT NULL DEFAULT '{}',
-    #     pub_type varchar(20) NOT NULL DEFAULT 'rss',
-    #     portal_url text,
-    #     rss_url text NOT NULL,
-    #     auto_publish boolean NOT NULL DEFAULT false,
-    #     first_seen timestamp NOT NULL DEFAULT now(),
-    #     last_seen timestamp NOT NULL DEFAULT now(),
-    #     pub_date timestamp
-    # )""")
-
-    # #pubid, rsid  Ingest, rs_record_id, eml_link, file_link, First Seen Date, Last Seen Date, Feed Date, Harvest Date, Harvest Etag
-    # db.execute("""CREATE TABLE IF NOT EXISTS recordsets (
-    #     id BIGSERIAL NOT NULL PRIMARY KEY,
-    #     uuid uuid UNIQUE,
-    #     publisher_uuid uuid REFERENCES publishers(uuid),
-    #     name text NOT NULL,
-    #     recordids text[] NOT NULL DEFAULT '{}',
-    #     eml_link text,
-    #     file_link text NOT NULL,
-    #     ingest boolean NOT NULL DEFAULT false,
-    #     first_seen timestamp NOT NULL DEFAULT now(),
-    #     last_seen timestamp NOT NULL DEFAULT now(),
-    #     pub_date timestamp,
-    #     harvest_date timestamp,
-    #     harvest_etag varchar(41)
-    # )""")
-    # db.commit()
-    db.close()
 
 def id_func(portal_url, e):
     id = None
@@ -442,6 +401,49 @@ def upload_recordset(rsid, fname, idbmodel):
         mo.ensure_media_object(idbmodel)
         return mo.etag
     logger.debug("Finished Upload of %r", rsid)
+
+
+def create_tables():
+    """
+    This function is out-of-sync with actual database, unmaintained.
+    Commenting out all action in this function, it will do nothing until modified again.
+    """
+
+    db = PostgresDB()
+    logger.error('create_tables called but has no valid code to run.')
+
+    # db.execute("""CREATE TABLE IF NOT EXISTS publishers (
+    #     id BIGSERIAL NOT NULL PRIMARY KEY,
+    #     uuid uuid UNIQUE,
+    #     name text NOT NULL,
+    #     recordids text[] NOT NULL DEFAULT '{}',
+    #     pub_type varchar(20) NOT NULL DEFAULT 'rss',
+    #     portal_url text,
+    #     rss_url text NOT NULL,
+    #     auto_publish boolean NOT NULL DEFAULT false,
+    #     first_seen timestamp NOT NULL DEFAULT now(),
+    #     last_seen timestamp NOT NULL DEFAULT now(),
+    #     pub_date timestamp
+    # )""")
+
+    # #pubid, rsid  Ingest, rs_record_id, eml_link, file_link, First Seen Date, Last Seen Date, Feed Date, Harvest Date, Harvest Etag
+    # db.execute("""CREATE TABLE IF NOT EXISTS recordsets (
+    #     id BIGSERIAL NOT NULL PRIMARY KEY,
+    #     uuid uuid UNIQUE,
+    #     publisher_uuid uuid REFERENCES publishers(uuid),
+    #     name text NOT NULL,
+    #     recordids text[] NOT NULL DEFAULT '{}',
+    #     eml_link text,
+    #     file_link text NOT NULL,
+    #     ingest boolean NOT NULL DEFAULT false,
+    #     first_seen timestamp NOT NULL DEFAULT now(),
+    #     last_seen timestamp NOT NULL DEFAULT now(),
+    #     pub_date timestamp,
+    #     harvest_date timestamp,
+    #     harvest_etag varchar(41)
+    # )""")
+    # db.commit()
+    db.close()
 
 
 def main():

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -273,9 +273,9 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
     else:
         logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}'".format(recordset["id"], feed_recordids, file_link))
 
-        logger.debug("Existing ID for this recordid: '{0}'".format(existing_recordsets["recordid"]))
-        logger.debug("Expected ID to update: '{0}'".format(recordset["id"]))
-        if existing_recordsets["recordid"] != recordset["id"]:
+        logger.debug("Existing DB id for this recordid: '{0}'".format(existing_recordsets[recordid]))
+        logger.debug("Expected DB id to update: '{0}'".format(recordset["id"]))
+        if existing_recordsets[recordid] != recordset["id"]:
             logger.debug("WOULD BE MAGIC CONDITION IF FOUND")
             # and then should not run the SQL
         sql = ("""UPDATE recordsets

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -153,9 +153,7 @@ def update_db_from_rss():
                 logger.debug("id | recordid | file_link: '{0}' | '{1}' | '{2}'".format(
                     row["id"], recordid, row["file_link"]))
                 if recordid in existing_recordsets:
-                    logger.error("Found a duplicate recordid in existing recordsets. This should never happen.")
-                    logger.error("This recordid = '{0}'"
-                        ". Other row = ''{1}''".format(recordid, existing_recordsets[recordid]))
+                    logger.error("recordid '{0}' already in existing recordsets. This should never happen.".format(recordid))
                 else:
                     existing_recordsets[recordid] = row["id"]
 

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -135,8 +135,7 @@ def update_db_from_rss():
             for recordid in r["recordids"]:
                 logger.debug("recordid | id : '{0}' | '{1}'".format(recordid, r["id"]))
                 existing_recordsets[recordid] = r["id"]
-            # I believe the bug for Redmine #3124 is multiple ids are added to the set, but by definition
-            # the set only keeps one of them.
+            # BZZZZP
             recordsets[r["id"]] = r
         #logger.debug("***existing_recordsets DUMP ***\n")
         #logger.debug("{0}".format(existing_recordsets))

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -284,7 +284,6 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
         db.execute(*sql)
         logger.info("Updated Recordset id:%s %s %s '%s'",
                     recordset["id"], recordset["uuid"], file_link, rs_name)
-        EARLY_EXIT("NEW FUNCTION _do_rss_entry end.")
 
 
 def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -357,8 +357,6 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
                       existing_recordsets,
                       pub_uuid) # (feedparser object, row of pub data, db object)
 
-    EARLY_EXIT("before set_record on pub_uuid")
-
     db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID,
                   {
                       "rss_url": r["rss_url"],

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -288,7 +288,7 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
             if recordset["id"] != file_links[file_link]:
                 logger.error("Skipping file_link: '{3}'. Found conflict or duplicate recordid. "
                              "Investigate db ids: '{0}' and '{1}'".format(
-                    recordset["id"], file_links[file_link]
+                    recordset["id"], file_links[file_link], file_link
                 ))
                 return
 

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -80,6 +80,7 @@ def id_func(portal_url, e):
             id = m.group(1)
 
         id = id.lower()
+    logger.debug ("id_func returning recorid '{0}' from portal url '{1}'".format(id, portal_url))
     return id
 
 
@@ -233,7 +234,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
     for e in feed['entries']:
         # why is the portal_url and not something like file_link ?
         recordid = id_func(r['portal_url'], e)
-        logger.debug ("id_func returned recorid '{0}' from portal url '{1}'".format(recordid, r['portal_url']))
+
         rsid = None
         ingest = auto_publish
         recordids = [recordid]

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -34,6 +34,9 @@ IDIGBIO_ROOT_UUID = "872733a2-67a3-4c54-aa76-862735a5f334"
 
 logger = idblogger.getChild('upr')
 
+def EARLY_EXIT(msg):
+    raise SystemExit("EARLY EXIT  " + msg)
+
 def struct_to_datetime(s):
     """
     Convert a Struct representation of a time to a datetime
@@ -232,6 +235,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
 
     logger.debug("Begin iteration over entries found in '{0}'".format(r['rss_url']))
     for e in feed['entries']:
+        logger.debug("feed entry: '{0}'".format(e))
         # why is the portal_url and not something like file_link ?
         recordid = id_func(r['portal_url'], e)
 
@@ -294,7 +298,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
         else:
             logger.debug("No recordid identified.")
 
-
+        EARLY_EXIT()
 
         if recordset is None:
             sql = (
@@ -329,6 +333,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
             logger.info("Update Recordset id:%s %s %s '%s'",
                         recordset["id"], recordset["uuid"], file_link, rs_name)
 
+    EARLY_EXIT("before set_record")
 
     db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID,
                   {
@@ -343,6 +348,8 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
 
 
 def harvest_all_eml():
+    EARLY_EXIT('harvest')
+
     sql = """SELECT *
              FROM recordsets
              WHERE eml_link IS NOT NULL
@@ -364,6 +371,8 @@ def harvest_all_eml():
                 logger.exception("failed Harvest EML %s %s", r["id"], r["name"])
 
 def harvest_eml(r, db):
+    EARLY_EXIT('harvest')
+
     logger.info("Harvest EML %s '%s' @ '%s'", r["id"], r["name"], r["eml_link"])
     fname = "{0}.eml".format(r["id"])
     if not download_file(r["eml_link"], fname):
@@ -396,6 +405,8 @@ def harvest_eml(r, db):
 
 
 def harvest_all_file():
+    EARLY_EXIT("before harvest")
+
     sql = """SELECT *
              FROM recordsets
              WHERE file_link IS NOT NULL
@@ -419,6 +430,7 @@ def harvest_all_file():
                 db.rollback()
 
 def harvest_file(r, db):
+    EARLY_EXIT('harvest_file')
     logger.info("Harvest File %s '%s' @ '%s'", r["id"], r["name"], r["file_link"])
     fname = "{0}.file".format(r["id"])
 
@@ -439,6 +451,8 @@ def harvest_file(r, db):
 
 
 def upload_recordset(rsid, fname, idbmodel):
+    EARLY_EXIT('upload_recordset')
+
     filereference = "http://api.idigbio.org/v1/recordsets/" + rsid
     logger.debug("Starting Upload of %r", rsid)
     stor = IDigBioStorage()

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -164,14 +164,25 @@ def update_db_from_rss():
             if rsscontents:
                 try:
                     _do_rss(rsscontents, row, db, recordsets, existing_recordsets)
+                    logger.debug('_do_rss returned, ready to COMMIT...')
                     db.commit()
                 except Exception:
-                    logger.exception("Error with %s %s", uuid, rss_url)
+                    logger.exception("Will ROLLBACK... Error with %s %s", uuid, rss_url)
                     db.rollback()
                 except:
+                    logger.exception("Will ROLLBACK...")
                     db.rollback()
                     raise
     logger.info("Finished processing add publisher RSS feeds")
+
+# def _do_rss_entry(e, db, ):
+#     """
+#     Do the recordset parts.
+#
+#     Parameters
+#     ----------
+#
+#     """
 
 
 def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
@@ -241,7 +252,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
     logger.debug("Begin iteration over entries found in '{0}'".format(r['rss_url']))
     for e in feed['entries']:
         logger.debug("feed entry: '{0}'".format(e))
-        # why is the portal_url and not something like file_link ?
+        # We pass in portal_url even though it is only needeed for Symbiota portals
         recordid = id_func(r['portal_url'], e)
 
         rsid = None
@@ -338,7 +349,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
             logger.info("Updated Recordset id:%s %s %s '%s'",
                         recordset["id"], recordset["uuid"], file_link, rs_name)
 
-    EARLY_EXIT("before set_record")
+    EARLY_EXIT("before set_record on pub_uuid")
 
     db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID,
                   {

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -133,10 +133,10 @@ def update_db_from_rss():
     with PostgresDB() as db:
         for r in db.fetchall("SELECT * FROM recordsets"):
             for recordid in r["recordids"]:
-                logger.debug("recordid | id : '{0}' | '{1}'.format(recordid, r["id"])")
+                logger.debug("recordid | id : '{0}' | '{1}'".format(recordid, r["id"]))
                 existing_recordsets[recordid] = r["id"]
             # I believe the bug for Redmine #3124 is multiple ids are added to the set, but by definition
-            # the set only keeps one of them. 
+            # the set only keeps one of them.
             recordsets[r["id"]] = r
         #logger.debug("***existing_recordsets DUMP ***\n")
         #logger.debug("{0}".format(existing_recordsets))

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -133,12 +133,13 @@ def update_db_from_rss():
     with PostgresDB() as db:
         for row in db.fetchall("SELECT * FROM recordsets"):
             for recordid in row["recordids"]:
-                logger.debug("recordid | id : '{0}' | '{1}'".format(recordid, row["id"]))
-# sample loglines, '1162234d-4e06-4d63-8a49-034184a38c7e' maps to multiple db ids
-#2019-06-30 22:24:46.456 DEBUG idb.upr:- recordid | id : '1162234d-4e06-4d63-8a49-034184a38c7e' | '4246'
-#2019-06-30 22:24:46.456 DEBUG idb.upr:- recordid | id : 'http://ipt.idigbio.org/resource?id=uprm-invcol' | '4246'
-#2019-06-30 22:24:47.108 DEBUG idb.upr:- recordid | id : '1162234d-4e06-4d63-8a49-034184a38c7e' | '12681'
-                existing_recordsets[recordid] = row["id"]
+                logger.debug("id | recordid | file_link: '{0}' | '{1}' | '{2}'".format(
+                    row["id"], recordid, row["file_link"]))
+                if recordid in existing_recordsets:
+                    logger.error("Found a duplicate recordid. This recordid = '{0}'"
+                        ". Other row = {1}".format(recordid, existing_recordsets[recordid]))
+                else:
+                    existing_recordsets[recordid] = row["id"]
             recordsets[row["id"]] = row
         #logger.debug("***existing_recordsets DUMP ***\n")
         #logger.debug("{0}".format(existing_recordsets))

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -286,9 +286,9 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
         # The DB id should match when doing a "reverse" look up by file_link.
         if file_link in file_links:
             if recordset["id"] != file_links[file_link]:
-                logger.error("Skipping file_link: '{0}'. Found conflict or duplicate recordid."
+                logger.error("Skipping file_link: '{0}'. Found conflict or duplicate recordid. "
                              "Investigate db ids: '{1}' and '{2}'".format(
-                    recordset["id"], file_links[file_link], file_link
+                    file_link, recordset["id"], file_links[file_link]
                 ))
                 return
 

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -390,7 +390,8 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets, file_links):
     for e in feed['entries']:
         _do_rss_entry(e, r['portal_url'], db, recordsets,
                       existing_recordsets,
-                      pub_uuid) # (feedparser object, row of pub data, db object)
+                      pub_uuid,
+                      file_links)
 
     db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID,
                   {

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -66,7 +66,8 @@ def id_func(portal_url, e):
 
     Parameters
     ----------
-    portal_url : a url to a data portal from the publishers table
+    portal_url : url string
+        A url to a data portal from the publishers table
     e : feedparser entry object (feedparser.FeedParserDict)
         An individual rss entry already processed into a feedparser dict.
 
@@ -180,22 +181,28 @@ def update_db_from_rss():
                     raise
     logger.info("Finished processing add publisher RSS feeds")
 
-def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uuid):
+def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uuid, file_links):
     """
     Do the recordset parts.
 
     Parameters
     ----------
     entry : feedparser entry object
-    portal_url : publisher portal url, needed for some id functions
+        Each field in the feedparser object is accessible via dict notation
+    portal_url : url string
+        publisher portal url, needed for some id functions
     db : db object
+        DB connection object
     recordsets : dict
-        dict of existing known recordset db ids with associated db row data
+        dict of existing known recordset DB ids with associated DB row data
     existing_recordsets : dict
-        dict of existing known recordset recordids with associated db ids
-    pub_uuid : publisher uuid
-    ....
+        dict of existing known recordset recordids with associated DB ids
+    pub_uuid : uuid
+        Publisher's uuid
+    file_links : dict
+        dict of existing known file_links with associated DB ids
     """
+
     logger.debug("In func _do_rss_entry")
 
     logger.debug("feed entry: '{0}'".format(entry))
@@ -327,11 +334,11 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets, file_links):
     db : database object
         A PostgresDB() database object
     recordsets : dict
-        dict of existing known recordset db ids with associated db row data
+        dict of existing known recordset DB ids with associated DB row data
     existing_recordsets : dict
-        dict of existing known recordset recordids with associated db ids
+        dict of existing known recordset recordids with associated DB ids
     file_links : dict
-        dict of existing know file_links with associated db ids
+        dict of existing known file_links with associated DB ids
     """
 
     logger.debug("Start parsing results of %s", r['rss_url'])

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -303,9 +303,8 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
         else:
             logger.debug("No recordid identified.")
 
-        EARLY_EXIT()
-
         if recordset is None:
+            logger.debug("Ready to INSERT: '{0}', '{1}', '{2}'".format(name, recordids, file_link))
             sql = (
                 """INSERT INTO recordsets
                      (uuid, publisher_uuid, name, recordids, eml_link, file_link, ingest, pub_date)
@@ -315,8 +314,9 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
                 """,
                 (rsid, pub_uuid, rs_name, recordids, eml_link, file_link, ingest, date, recordid, date))
             db.execute(*sql)
-            logger.info("Create Recordset for recordid:%s '%s'", recordid, rs_name)
+            logger.info("Created Recordset for recordid:%s '%s'", recordid, rs_name)
         else:
+            logger.debug("Ready to UPDATE: '{0}', '{1}', '{2}', '{3}'".format(uuid, name, recordids, file_link))
             sql = ("""UPDATE recordsets
                       SET publisher_uuid=%(publisher_uuid)s,
                           eml_link=%(eml_link)s,
@@ -335,7 +335,7 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
                        "id": recordset["id"]
                    })
             db.execute(*sql)
-            logger.info("Update Recordset id:%s %s %s '%s'",
+            logger.info("Updated Recordset id:%s %s %s '%s'",
                         recordset["id"], recordset["uuid"], file_link, rs_name)
 
     EARLY_EXIT("before set_record")

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -28,6 +28,9 @@ from idigbio_ingestion.lib.eml import parseEml
 #urllib3.disable_warnings()
 ####
 
+# uuid '872733a2-67a3-4c54-aa76-862735a5f334' is the idigbio root entity,
+# the parent of all publishers.
+IDIGBIO_ROOT_UUID = "872733a2-67a3-4c54-aa76-862735a5f334"
 
 logger = idblogger.getChild('upr')
 
@@ -51,6 +54,16 @@ def struct_to_datetime(s):
 
 
 def id_func(portal_url, e):
+    """
+    Given a portal url, return something suitable to be used as a recordid.
+
+    Parameters
+    ----------
+    portal_url : a url to a data portal ?
+    e :
+
+    """
+
     id = None
     if "id" in e:   # feedparser magic maps various fields to "id"
         id = e["id"]
@@ -204,8 +217,11 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
            })
     db.execute(*sql)
 
+    logger.debug("Begin iteration over entries found in '{0}'".format(r['rss_url'])
     for e in feed['entries']:
+        logger.debug ("'e' in feed is of type {0}".format(type(e)))
         recordid = id_func(r['portal_url'], e)
+        logger.debug ("id_func returned '{0}'".format(recordid))
         rsid = None
         ingest = auto_publish
         recordids = [recordid]
@@ -297,7 +313,8 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
             logger.info("Update Recordset id:%s %s %s '%s'",
                         recordset["id"], recordset["uuid"], file_link, rs_name)
 
-    db.set_record(pub_uuid, "publisher", "872733a2-67a3-4c54-aa76-862735a5f334",
+
+    db.set_record(pub_uuid, "publisher", IDIGBIO_ROOT_UUID)
                   {
                       "rss_url": r["rss_url"],
                       "name": name,

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -55,12 +55,14 @@ def struct_to_datetime(s):
 
 def id_func(portal_url, e):
     """
-    Given a portal url, return something suitable to be used as a recordid.
+    Given a portal url and a feedparser RSS dictionary,
+    return something suitable to be used as a recordid.
 
     Parameters
     ----------
-    portal_url : a url to a data portal ?
-    e :
+    portal_url : a url to a data portal
+    e : feedparser object (feedparser.FeedParserDict)
+        An individual rss entry already processed into a feedparser dict.
 
     """
 
@@ -219,7 +221,6 @@ def _do_rss(rsscontents, r, db, recordsets, existing_recordsets):
 
     logger.debug("Begin iteration over entries found in '{0}'".format(r['rss_url']))
     for e in feed['entries']:
-        logger.debug ("'e' in feed is of type {0}".format(type(e)))
         recordid = id_func(r['portal_url'], e)
         logger.debug ("id_func returned '{0}'".format(recordid))
         rsid = None

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -67,7 +67,7 @@ def id_func(portal_url, e):
     Parameters
     ----------
     portal_url : a url to a data portal from the publishers table
-    e : feedparser object (feedparser.FeedParserDict)
+    e : feedparser entry object (feedparser.FeedParserDict)
         An individual rss entry already processed into a feedparser dict.
 
     """
@@ -214,7 +214,7 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
         date = struct_to_datetime(entry["published_parsed"])
         logger.debug('pub_date struct via published_parsed: {0}'.format(date.isoformat()))
     elif "published" in entry and entry["published"] is not None:
-        date = dateutil.parser.parse(e["published"])
+        date = dateutil.parser.parse(entry["published"])
         logger.debug('pub_date via dateutil: {0}'.format(date.isoformat()))
 
     # Pick a time distinctly before now() to avoid data races

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -59,25 +59,30 @@ def struct_to_datetime(s):
 def id_func(portal_url, e):
     """
     Given a portal url and an RSS feed entry (feedparser dictionary
-    object), return something suitable to be used as a recordid.
+    object), return something suitable to be used as a recordid
+    for the published dataset entry.  The portal_url is only used
+    to help construct a recordid for Symbiota recordsets.
+
 
     Parameters
     ----------
-    portal_url : a url to a data portal
+    portal_url : a url to a data portal from the publishers table
     e : feedparser object (feedparser.FeedParserDict)
         An individual rss entry already processed into a feedparser dict.
 
     """
 
     id = None
-    if "id" in e:   # feedparser magic maps various fields to "id" including "guid"
+    # feedparser magic maps various fields to "id" including "guid"
+    if "id" in e:
         id = e["id"]
+    # portal_url is used to help construct ids in Symbiota feeds
     elif "collid" in e:
         id = "{0}collections/misc/collprofiles.php?collid={1}".format(
             portal_url, e["collid"])
 
     if id is not None:
-        # Strip version from ipt ids
+        # Strip trailing version info from ipt ids
         m = re.search('^(.*)/v[0-9]*(\.)?[0-9]*$', id)
         if m is not None:
             id = m.group(1)


### PR DESCRIPTION
This should now not be a fatal exception that stops processing an entire RSS feed:

```
Error with 5ded2005-0563-4737-9830-e951dab59c66 http://ipt.tacc.utexas.edu/rss.do
DETAIL:  Key (file_link)=(http://ipt.tacc.utexas.edu/archive.do?r=npl) already exists.
```

Now will skip items (and log ERROR) that have a recordid conflict (the same recordid appearing in two different feeds) instead of completely aborting an entire feed.  A few other cases may also be resolved.

See redmine 3124.

Other refactoring to improve maintainability.
