### PR TITLE
add ChronometricAge extension

### DIFF
--- a/idb/helpers/fieldnames.py
+++ b/idb/helpers/fieldnames.py
@@ -58,7 +58,8 @@ types = {
     "http://rs.tdwg.org/dwc/terms/Occurrence": { "shortname": "dwc:Occurrence" },
     "http://rs.tdwg.org/dwc/terms/ResourceRelationship": { "shortname": "dwc:ResourceRelationship" },
     "http://rs.tdwg.org/dwc/terms/Taxon": {"shortname": "dwc:Taxon"},
-    "http://zooarchnet.org/dwc/terms/ChronometricDate": {"shortname": "zan:ChronometricDate"}
+    "http://zooarchnet.org/dwc/terms/ChronometricDate": {"shortname": "zan:ChronometricDate"},
+    "http://zooarchnet.org/dwc/terms/ChronometricAge": {"shortname": "zan:ChronometricAge"}
 }
 
 '''


### PR DESCRIPTION
fixes
```
root@c18node4:/mnt/data/new_ingestion# cat b293a647-5fb8-4b82-bf5b-571e7d6fad03.db_check.log 
2019-08-07 22:53:57.582 INFO  idb.db-check.b293a647-5fb8-4b82-bf5b-571e7d6fad03჻ Starting db_check ingest: False
2019-08-07 22:53:57.602 INFO  idb.db-check.b293a647-5fb8-4b82-bf5b-571e7d6fad03჻ Fetching etag 9f0a9ad6c1d1da14e49445c0fc43b07f to 'b293a647-5fb8-4b82-bf5b-571e7d6fad03'
2019-08-07 22:53:57.706 INFO  idb.db-check.b293a647-5fb8-4b82-bf5b-571e7d6fad03჻ Building ids/uuids json
2019-08-07 22:53:57.806 INFO  idb.db-check.b293a647-5fb8-4b82-bf5b-571e7d6fad03჻ Processing b293a647-5fb8-4b82-bf5b-571e7d6fad03, type: application/zip
2019-08-07 22:53:58.362 INFO  idb.b293a647-5fb8-4b82-bf5b-571e7d6fad03჻ Schema validation failed, continuing unvalidated
2019-08-07 22:53:58.364 DEBUG idb.b293a647-5fb8-4b82-bf5b-571e7d6fad03჻ Traceback (most recent call last):
  File "/root/idb-backend/idigbio_ingestion/lib/dwca.py", line 60, in __init__
    root = etree.parse(meta, parser=parser).getroot()
  File "src/lxml/lxml.etree.pyx", line 3427, in lxml.etree.parse (src/lxml/lxml.etree.c:81110)
  File "src/lxml/parser.pxi", line 1832, in lxml.etree._parseDocument (src/lxml/lxml.etree.c:118109)
  File "src/lxml/parser.pxi", line 1852, in lxml.etree._parseFilelikeDocument (src/lxml/lxml.etree.c:118392)
  File "src/lxml/parser.pxi", line 1747, in lxml.etree._parseDocFromFilelike (src/lxml/lxml.etree.c:117180)
  File "src/lxml/parser.pxi", line 1162, in lxml.etree._BaseParser._parseDocFromFilelike (src/lxml/lxml.etree.c:111907)
  File "src/lxml/parser.pxi", line 595, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:105102)
  File "src/lxml/parser.pxi", line 706, in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:106810)
  File "src/lxml/parser.pxi", line 635, in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:105664)
XMLSyntaxError: Element '{http://rs.tdwg.org/dwc/text/}coreid': This element is not expected. Expected is ( {http://rs.tdwg.org/dwc/text/}coreId ). (line 0)

2019-08-07 22:53:58.375 ERROR idb.db-check჻ Unhandled Exception when processing b293a647-5fb8-4b82-bf5b-571e7d6fad03
Traceback (most recent call last):
  File "/root/idb-backend/idigbio_ingestion/db_check.py", line 403, in process_file
    dwcaobj = Dwca(fname, skipeml=True, logname="idb")
  File "/root/idb-backend/idigbio_ingestion/lib/dwca.py", line 119, in __init__
    logname=self.logger.name))
  File "/root/idb-backend/idigbio_ingestion/lib/dwca.py", line 202, in __init__
    logname=self.logger.name)
  File "/root/idb-backend/idigbio_ingestion/lib/delimited.py", line 99, in __init__
    raise TypeError("{} not mapped to short name".format(self.rowtype))
TypeError: http://zooarchnet.org/dwc/terms/ChronometricAge not mapped to short name
2019-08-07 22:53:58.377 INFO  idb.db-check჻ b293a647-5fb8-4b82-bf5b-571e7d6fad03 writing summary json
2019-08-07 22:53:58.447 INFO  idb.db-check.b293a647-5fb8-4b82-bf5b-571e7d6fad03჻ Finished db_check in 0.864s
```