### PR TITLE
fix pip install systemd-python issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@
 # This is an implicit value, here for clarity
 --index-url https://pypi.python.org/simple/
 
-https://github.com/systemd/python-systemd/archive/v231.tar.gz#egg=python-systemd
+https://github.com/systemd/python-systemd/archive/v234.tar.gz
 -e .[ingestion,test,journal]

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'jsonlines>=1.1.3',
     ],
     extras_require={
-        'journal': ['python-systemd>=230'],
+        'journal': ['systemd-python>=230'],
         'ingestion': [
             'pydub==0.16.5',
             'pillow-simd>=3.4',


### PR DESCRIPTION
Trying to `pip install -r requirements.txt`

got:

```Building wheels for collected packages: python-systemd
  Building wheel for python-systemd (setup.py) ... error
  ERROR: Command errored out with exit status 1:
...
```

These changes to requirements.txt and setup.py appear fix this issue.