### PR TITLE
Manual dataset upload to work 

### DIFF
--- a/idigbio_ingestion/cli.py
+++ b/idigbio_ingestion/cli.py
@@ -16,6 +16,17 @@ def update_publisher_recordset():
     from idigbio_ingestion.update_publisher_recordset import main
     main()
 
+@cli.command(name="upload-recordset-from-file",
+             help="Run the upload step for a single local dataset file manually. "
+             "This skips all RSS feed processing.")
+@click.argument("rsid", type=click.UUID)
+@click.argument("file", type=click.Path())
+@fnlogged
+def manual_update_recordset_from_file(rsid, file):
+    from idigbio_ingestion.update_publisher_recordset import upload_recordset_from_file
+    upload_recordset_from_file(rsid, file)
+
+
 @cli.command(name="db-check",
              help="Check a dataset, by rsid, against the database "
              "and report what will be ingested")

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -538,6 +538,7 @@ def upload_recordset_from_file(rsid, fname):
     rsuuid = str(rsid)
 
     logger.info("Manual upload of '{0}' from file '{1}' requested.".format(rsuuid, fname))
+
     # do some checks here
     try:
         f = open(fname)
@@ -546,18 +547,18 @@ def upload_recordset_from_file(rsid, fname):
         logger.error("Cannot access file: '{0}'. Aborting upload.".format(fname))
         raise
     db = PostgresDB()
-
-    # output the "before" state
-    results = db.fetchall("""SELECT id,file_harvest_date,file_harvest_etag FROM recordsets WHERE uuid=%s""", (rsuuid, ))
-    for each in results:
-        logger.debug("{0}".format(each))
-
     sql = ("""SELECT id FROM recordsets WHERE uuid=%s""", (rsuuid, ))
     idcount = db.execute(*sql)
     if idcount < 1:
         logger.error("Cannot find uuid '{0}' in db.  Aborting upload.".format(rsuuid))
         db.rollback()
         return False
+
+    # output the "before" state
+    results = db.fetchall("""SELECT id,file_harvest_date,file_harvest_etag FROM recordsets WHERE uuid=%s""", (rsuuid, ))
+    for each in results:
+        logger.debug("{0}".format(each))
+
     try:
         etag = upload_recordset(rsuuid, fname, db)
         assert etag

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -571,7 +571,7 @@ def upload_recordset_from_file(rsid, fname):
         logger.info("UPDATED {0} rows.".format(update_count))
         logger.info("Finished manual upload of file '{0}', result etag = '{1}', saved to db.".format(fname, etag))
     except:
-        logger.error("An exception occurred during upload of file '{0}'".format(fname))
+        logger.error("An exception occurred during upload of file or db update for '{0}'".format(fname))
         raise
     # output the "after" state
     results = db.fetchall("""SELECT id,file_harvest_date,file_harvest_etag FROM recordsets WHERE uuid=%s""", (rsuuid, ))

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -510,9 +510,74 @@ def upload_recordset(rsid, fname, idbmodel):
         mo.ensure_media(idbmodel)
         mo.ensure_object(idbmodel)
         mo.ensure_media_object(idbmodel)
-        logger.debug("Finished Upload of %r, etag = %m", rsid, mo.etag)
+        logger.debug("Finished Upload of %r, etag = %s", rsid, mo.etag)
         return mo.etag
 
+
+def upload_recordset_from_file(rsid, fname):
+    """
+    Given a recordset uuid and a local dataset filename, upload the local
+    dataset file as the "current" file for that uuid.
+
+    Parameters
+    ----------
+    rsid : uuid
+        An iDigBio recordset uuid
+    fname : string
+        Filename (full path or current directory only)
+
+    Returns
+    -------
+    bool
+        True if successful, False otherwise
+    """
+    # convert rsid uuid to string here because of either:
+    #   psycopg2.ProgrammingError: can't adapt type 'UUID'
+    # or
+    #  TypeError: 'UUID' object does not support indexing
+    rsuuid = str(rsid)
+
+    logger.info("Manual upload of '{0}' from file '{1}' requested.".format(rsuuid, fname))
+    # do some checks here
+    try:
+        f = open(fname)
+        f.close()
+    except:
+        logger.error("Cannot access file: '{0}'. Aborting upload.".format(fname))
+        raise
+    db = PostgresDB()
+
+    # output the "before" state
+    results = db.fetchall("""SELECT id,file_harvest_date,file_harvest_etag FROM recordsets WHERE uuid=%s""", (rsuuid, ))
+    for each in results:
+        logger.debug("{0}".format(each))
+
+    sql = ("""SELECT id FROM recordsets WHERE uuid=%s""", (rsuuid, ))
+    idcount = db.execute(*sql)
+    if idcount < 1:
+        logger.error("Cannot find uuid '{0}' in db.  Aborting upload.".format(rsuuid))
+        db.rollback()
+        return False
+    try:
+        etag = upload_recordset(rsuuid, fname, db)
+        assert etag
+        sql = ("""UPDATE recordsets
+                  SET file_harvest_etag=%s, file_harvest_date=%s
+                  WHERE uuid=%s""",
+               (etag, datetime.datetime.now(), rsuuid))
+        update_count = db.execute(*sql)
+        db.commit()
+        logger.info("UPDATED {0} rows.".format(update_count))
+        logger.info("Finished manual upload of file '{0}', result etag = '{1}', saved to db.".format(fname, etag))
+    except:
+        logger.error("An exception occurred during upload of file '{0}'".format(fname))
+        raise
+    # output the "after" state
+    results = db.fetchall("""SELECT id,file_harvest_date,file_harvest_etag FROM recordsets WHERE uuid=%s""", (rsuuid, ))
+    for each in results:
+        logger.debug("{0}".format(each))
+
+    return True
 
 
 def create_tables():


### PR DESCRIPTION
Add a way to manually upload a dataset file for a given recordset uuid, out-of-band with the normal RSS processing.

Needed to work around Naturalis API issues (unable to retrieve the entire archive most of the time).