### PR TITLE
catch other exceptions such as when db is missing

### DIFF
--- a/idb/postgres_backend/gevent_helpers.py
+++ b/idb/postgres_backend/gevent_helpers.py
@@ -72,6 +72,10 @@ class GeventedConnPool(object):
             except:
                 self.lock.release()
                 raise
+        except Exception as e:
+            logger.exception(type(e))
+            logger.exception(e)
+            raise
 
     def put(self, conn):
         assert conn is not None


### PR DESCRIPTION
fixes #60 

db connect error etc. will cause exception to be raised, fatal and kill the service.