### PR TITLE
create the index if it does not exist

### DIFF
--- a/idb/config.py
+++ b/idb/config.py
@@ -47,7 +47,7 @@ for p in conf_paths:
     except IOError:
         pass
 
-
+# These become available as config.VARIABLE when imported e.g. 'from idb import config'
 ENV = os.environ.get('ENV', 'dev')
 IDB_UUID = os.environ.get('IDB_UUID')
 IDB_APIKEY = os.environ.get('IDB_APIKEY')
@@ -56,3 +56,8 @@ IDB_STORAGE_HOST = os.environ.get('IDB_STORAGE_HOST', 's.idigbio.org')
 IDB_STORAGE_ACCESS_KEY = os.environ.get('IDB_STORAGE_ACCESS_KEY')
 IDB_STORAGE_SECRET_KEY = os.environ.get('IDB_STORAGE_SECRET_KEY')
 IDB_CRYPT_KEY = os.environ.get('IDB_CRYPT_KEY')
+
+ES_ALLOW_INDEX_CREATION = os.environ.get('ES_ALLOW_INDEX_CREATION', 'no')
+ES_INDEX_CHUNK_SIZE = os.environ.get('ES_INDEX_CHUNK_SIZE', '1000')
+ES_INDEX_NUMBER_OF_SHARDS = os.environ.get('ES_INDEX_NUMBER_OF_SHARDS', '48')
+ES_INDEX_NUMBER_OF_REPLICAS = os.environ.get('ES_INDEX_NUMBER_OF_REPLICAS', '2')

--- a/idb/indexing/__init__.py
+++ b/idb/indexing/__init__.py
@@ -20,7 +20,7 @@ from idb.helpers.logging import fnlogged
               default=True,
               help="Enable/disable the record corrector, Default: enabled")
 @click.option('--types', '-t',
-              # TODO: this should porbably be `idb.helpers.conversions.fields.keys()`
+              # TODO: this should probably be `idb.helpers.conversions.fields.keys()`
               type=click.Choice([
                   'publishers', 'recordsets', 'mediarecords', 'records']),
               multiple=True)

--- a/idb/indexing/__init__.py
+++ b/idb/indexing/__init__.py
@@ -40,6 +40,14 @@ def cli(ctx, index, corrections, types, indexname):
         indexname = config.config["elasticsearch"]["indexname"]
     serverlist = config.config["elasticsearch"]["servers"]
 
+    if config.ENV == 'dev':
+        logger.info("Enabling dev configuration")
+        indexname = "dev-local"
+        serverlist = [
+            "localhost"
+        ]
+
+
     if config.ENV == 'beta':
         logger.info("Enabling beta configuration")
         indexname = "2.5.0"

--- a/idb/indexing/index_from_postgres.py
+++ b/idb/indexing/index_from_postgres.py
@@ -18,7 +18,7 @@ from idb.postgres_backend.db import tombstone_etag
 
 import elasticsearch.helpers
 
-logger = idblogger.getChild('indexing')
+logger = idblogger.getChild('indexer')
 configure(logger=logger, stderr_level=logging.INFO)
 
 last_afters = {}
@@ -48,7 +48,7 @@ def rate_logger(prefix, iterator, every=10000):
 def type_yield(ei, rc, typ, yield_record=False):
     # drop the trailing s
     pg_typ = "".join(typ[:-1])
-
+    logger.info("Fetching rows for: %s", typ)
     sql = "SELECT * FROM idigbio_uuids_data WHERE type=%s AND deleted=false"
     results = apidbpool.fetchiter(sql, (pg_typ,),
                                   named=True, cursor_factory=DictCursor)

--- a/idb/indexing/index_from_postgres.py
+++ b/idb/indexing/index_from_postgres.py
@@ -18,7 +18,7 @@ from idb.postgres_backend.db import tombstone_etag
 
 import elasticsearch.helpers
 
-logger = idblogger.getChild('indexer_from_postgres')
+logger = idblogger.getChild('index_from_postgres')
 configure(logger=logger, stderr_level=logging.INFO)
 
 last_afters = {}
@@ -268,6 +268,7 @@ def resume(ei, rc, also_delete=False, no_index=False):
 
 
 def full(ei, rc, no_index=False):
+    logger.info("Begin 'full' indexing...")
     consume(ei, rc, type_yield, no_index=no_index)
 
 

--- a/idb/indexing/index_from_postgres.py
+++ b/idb/indexing/index_from_postgres.py
@@ -301,7 +301,6 @@ def consume(ei, rc, iter_func, no_index=False):
         index_func = functools.partial(index_record, ei, rc, typ, do_index=False)
 
         to_index = iter_func(ei, rc, typ, yield_record=True)
-        #index_record_tuples = Pool(10).imap(index_func, to_index, 100)
         index_record_tuples = itertools.imap(index_func, to_index)
 
         if no_index:

--- a/idb/indexing/index_from_postgres.py
+++ b/idb/indexing/index_from_postgres.py
@@ -18,7 +18,7 @@ from idb.postgres_backend.db import tombstone_etag
 
 import elasticsearch.helpers
 
-logger = idblogger.getChild('indexer')
+logger = idblogger.getChild('indexer_from_postgres')
 configure(logger=logger, stderr_level=logging.INFO)
 
 last_afters = {}

--- a/idb/indexing/indexer.py
+++ b/idb/indexing/indexer.py
@@ -113,7 +113,7 @@ class ElasticSearchIndexer(object):
         # If the index does not exist, create it.
         if not self.es.indices.exists(index=self.indexName):
             logger.info("Index not found.  Creating: %s", self.indexName)
-            self.__create_index(self.indexName)
+            self.__create_index()
 
         # We POST the mappings every time an indexer object is created
         # regardless of actual indexing operation we are going to do.

--- a/idb/indexing/indexer.py
+++ b/idb/indexing/indexer.py
@@ -139,7 +139,7 @@ class ElasticSearchIndexer(object):
         Create an index with appropriate shard count and replicas for the cluster.
         """
         # create(index, body=None, params=None, headers=None)
-        res = self.es.create(index=self.indexName, body=ES_INDEX_CREATE_SETTINGS)
+        res = self.es.indices.create(index=self.indexName, body=ES_INDEX_CREATE_SETTINGS)
         logger.info("Create new Index: %s - %s", self.indexName, res)
 
     def esMapping(self, t):

--- a/idb/indexing/indexer.py
+++ b/idb/indexing/indexer.py
@@ -215,7 +215,7 @@ class ElasticSearchIndexer(object):
                 "type": "records"
             }
         res = self.es.indices.put_mapping(index=self.indexName, doc_type=t, body={t: m})
-        logger.debug("Built mapping for %s: %s", t, res)
+        logger.info("Built mapping for %s: %s", t, res)
 
     def index(self, t, i):
         """

--- a/idb/indexing/indexer.py
+++ b/idb/indexing/indexer.py
@@ -139,7 +139,7 @@ class ElasticSearchIndexer(object):
         Create an index with appropriate shard count and replicas for the cluster.
         """
         # create(index, body=None, params=None, headers=None)
-        res = self.es.create(self.indexName, body=ES_INDEX_CREATE_SETTINGS)
+        res = self.es.create(index=self.indexName, body=ES_INDEX_CREATE_SETTINGS)
         logger.info("Create new Index: %s - %s", self.indexName, res)
 
     def esMapping(self, t):

--- a/idb/indexing/indexer.py
+++ b/idb/indexing/indexer.py
@@ -139,7 +139,7 @@ class ElasticSearchIndexer(object):
         Create an index with appropriate shard count and replicas for the cluster.
         """
         # create(index, body=None, params=None, headers=None)
-        res = self.es.create(self.indexname, body=ES_INDEX_CREATE_SETTINGS)
+        res = self.es.create(self.indexName, body=ES_INDEX_CREATE_SETTINGS)
         logger.info("Create new Index: %s - %s", self.indexName, res)
 
     def esMapping(self, t):


### PR DESCRIPTION
Create the index if it does not exist and specify the settings appropriate for the cluster (shard count and replicas).

- Create index requires an additional environment variable to be set: `ES_ALLOW_INDEX_CREATION=yes`
- Moved a number of items into `config` object.
- Add some loglines.
- If ENV is `dev` do not try to connect to remote Elasticsearch cluster (use `localhost`).

Closes #98 
Closes #70 

Sample:

```
idb -v --logfile ./index-test-creates.log index --indexname dan-test-creates-index --no-index full
20:00:59.063 INFO  idb.indexing჻ Enabling no-index dry run mode
20:00:59.065 INFO  idb.indexer჻ Initializing ElasticSearchIndexer(u'dan-test-creates-index', [u'publishers', u'recordsets', u'mediarecords', u'records'], First cluster node: u'c20node1.acis.ufl.edu:9200')
20:00:59.075 INFO  idb.indexer჻ Index 'idigbio-dan-test-creates-index' not found.  If you wish to create it, set ES_ALLOW_INDEX_CREATION=yes environment variable.
```
