### PR TITLE
use python-systemd Ubuntu package instead of systemd-python pip package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For Ingestion and Development, the following are also needed:
 
 In Ubuntu 16.04, 18.04:
 
-    apt-get install libxml2 libxslt1-dev ffmpeg fonts-dejavu-core libfreetype6-dev
+    apt-get install libxml2 libxslt1-dev ffmpeg fonts-dejavu-core libfreetype6-dev python-systemd
 
 
 ### Package installation
@@ -51,7 +51,6 @@ For partial installation (without extra components) you can just run
 
 The available extra components are:
 
- * `journal`: Writes directly to systemd-journald
  * `ingestion`:  the extra librs for running ingestion
  * `test`: the extra libs for testing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@
 # This is an implicit value, here for clarity
 --index-url https://pypi.python.org/simple/
 
-https://github.com/systemd/python-systemd/archive/v234.tar.gz
--e .[ingestion,test,journal]
+-e .[ingestion,test]

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
         'jsonlines>=1.1.3',
     ],
     extras_require={
-        'journal': ['systemd-python>=230'],
         'ingestion': [
             'pydub==0.16.5',
             pillow_package,


### PR DESCRIPTION
The PyPi package `systemd-python` cannot handle our unicode characters in dataset names such as:

  'ZUEC-HEM - Coleção de Hemiptera do Museu de Zoologia da UNICAMP - Version 1.48'

We get errors such as:

```
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]: UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 144: ordinal not in range(128)
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]: Logged from file update_publisher_recordset.py, line 311
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]: Traceback (most recent call last):
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]:   File "/usr/local/lib/python2.7/dist-packages/systemd/journal.py", line 602, in emit
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]:     **extras)
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]:   File "/usr/local/lib/python2.7/dist-packages/systemd/journal.py", line 456, in send
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]:     args.extend(_make_line(key, val) for key, val in kwargs.items())
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]:   File "/usr/local/lib/python2.7/dist-packages/systemd/journal.py", line 456, in <genexpr>
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]:     args.extend(_make_line(key, val) for key, val in kwargs.items())
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]:   File "/usr/local/lib/python2.7/dist-packages/systemd/journal.py", line 409, in _make_line
Aug 17 20:48:21 c18node4 idigbio-ingestion[22407]:     return field + '=' + str(value)

```

The system (Ubuntu) package `python-systemd` works properly.

Remove the special 'journal' package group from our python environment setup, depend
on the system package instead.