### PR TITLE
Catch empty string encoding

### DIFF
--- a/idigbio_ingestion/lib/delimited.py
+++ b/idigbio_ingestion/lib/delimited.py
@@ -47,7 +47,7 @@ class DelimitedFile(object):
 
         # if incoming encoding is specified but is an empty string, we should abort here rather than
         # waiting for the actual file processing to raise an exception.
-        if encoding = "":
+        if encoding == "":
             raise ValueError("Encoding cannot be an empty string, must specify an actual encoding.")
         else:
             self.encoding = encoding

--- a/idigbio_ingestion/lib/delimited.py
+++ b/idigbio_ingestion/lib/delimited.py
@@ -45,7 +45,12 @@ class DelimitedFile(object):
     def __init__(self, fh, encoding="utf8", delimiter=",", fieldenc="\"", header=None, rowtype=None, logname=None):
         super(DelimitedFile, self).__init__()
 
-        self.encoding = encoding
+        # if incoming encoding is specified but is an empty string, we should abort here rather than
+        # waiting for the actual file processing to raise an exception.
+        if encoding = "":
+            raise ValueError("Encoding cannot be an empty string, must specify an actual encoding.")
+        else:
+            self.encoding = encoding
         self.fieldenc = fieldenc
         self.delimiter = delimiter
         self.rowtype = rowtype


### PR DESCRIPTION
In meta.xml, `encoding=""` is not valid and should be caught immediately.