### PR TITLE
pin version of pyquery since newest lib is incompatible with py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
             pillow_package,
             'lxml',
             'chardet',
-            'pyquery>=1.2',
+            'pyquery==1.2',
         ],
         'test': [
             'pytest>=3.0',


### PR DESCRIPTION
Latest (1.4.x) pyquery breaks in python 2 because it is using incompatible import:

```
    from urllib.parse import urlencode
E   ImportError: No module named parse
```

Pin the pyquery version to one known to work in python 2.
