### PR TITLE
pin pyquery to latest compatible minor version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
             pillow_package,
             'lxml',
             'chardet',
-            'pyquery==1.2',
+            'pyquery==1.2.17',
         ],
         'test': [
             'pytest>=3.0',


### PR DESCRIPTION
It seems that specifying 'pyquery==1.2' was not
getting the latest patch version under 1.2.  pip was installing
literal 1.2 version.

We need at least 1.2.7 for a particular `.text()` behavior, and
1.2.17 is the latest and known to work.

We still cannot move the the next minor version afaik.