### PR TITLE
Derivatives multiprocessing procs fix, tweak timer

### DIFF
--- a/etc/systemd/system/idigbio-ingestion-derivatives.timer
+++ b/etc/systemd/system/idigbio-ingestion-derivatives.timer
@@ -3,8 +3,8 @@ Description="Timer for idigbio-ingestion derivatives"
 
 [Timer]
 OnBootSec=13min
-OnUnitInactiveSec=10min
-RandomizedDelaySec=4m
+OnUnitInactiveSec=1min
+RandomizedDelaySec=15
 
 [Install]
 WantedBy=timers.target

--- a/idigbio_ingestion/mediaing/derivatives.py
+++ b/idigbio_ingestion/mediaing/derivatives.py
@@ -55,13 +55,12 @@ def main(buckets, procs=2):
         buckets = ('images', 'sounds')
     objects = objects_for_buckets(buckets)
 
-
     t1 = datetime.now()
     logger.info("Checking derivatives for %d objects", len(objects))
 
     if procs > 1:
         apidbpool.closeall()
-        pool = gipcpool.Pool(procs)
+        pool = gipcpool.Pool(size=procs)
         c = ilen(pool.imap_unordered(process_objects, grouper(objects, 1000)))
         logger.debug("Finished %d subprocesses", c)
     else:


### PR DESCRIPTION
* modify systemd timer to shorten delay between derivative runs
* `size` is a named parameter.  The cli option `--procs` now properly gets used through when creating the Pool

Fixes #142