### PR TITLE
remove un-used readline function

### DIFF
--- a/idigbio_ingestion/lib/dwca.py
+++ b/idigbio_ingestion/lib/dwca.py
@@ -207,9 +207,3 @@ class DwcaRecordFile(DelimitedFile):
         while ignoreheader > 0:
             self._reader.next()
             ignoreheader -= 1
-
-    def readline(self,size=None):
-        lineDict = {}
-        lineDict.update(self.defaults)
-        lineDict.update(super(DwcaRecordFile,self).readline(size))
-        return lineDict


### PR DESCRIPTION
readline in dwca.py is un-used, I think.

dwca.py is concerned with the archive file itself.

The reading of the constituent files happens in delimited.py which
has its own readline function defined.