### PR TITLE
truncate problematic objects containing dots in fieldnames

### DIFF
--- a/idb/indexing/index_helper.py
+++ b/idb/indexing/index_helper.py
@@ -74,7 +74,7 @@ def index_record(ei, rc, typ, r, do_index=True):
                     d["flag_data_" + prefix + "_" + suffix + "_munge"] = True
             if k in UNINDEXABLE_OBJECTS:
                 # inventing a new flag for each field we are truncating
-                new_flag = "_".join(["flag", "idigbio", k.replace(":","_").lower(), "removed"])
+                new_flag = "_".join(["flag", "idigbio", k.replace(":","_").lower(), "truncated"])
                 d[new_flag] = True
                 # truncate the troublesome object to prevent Elasticsearch mapper_parsing_exception
                 d[k] = {}

--- a/idb/indexing/index_helper.py
+++ b/idb/indexing/index_helper.py
@@ -12,6 +12,11 @@ logger = idblogger.getChild('index_helper')
 # PYTHON3_WARNING
 from urlparse import urlparse
 
+
+# A problematic field name is "http://rs.iobis.org/obis/terms/measurementTypeID" inside
+# the "obis:ExtendedMeasurementOrFact".
+UNINDEXABLE_OBJECTS = ["obis:ExtendedMeasurementOrFact"]
+
 def index_record(ei, rc, typ, r, do_index=True):
     """
     Index a single database record.
@@ -51,8 +56,8 @@ def index_record(ei, rc, typ, r, do_index=True):
         g = grabAll(typ, d)
         i = prepForEs(typ, g)
 
-        # Remove fieldnames with dots in them
-        # to fix an issue converting to ES 2.3+
+        # Fixup problematic field names due to limitations of Elasticsearch.
+        # For example, dots in fieldnames.
         for k in r["data"]:
             if "." in k:
                 if k in types:
@@ -67,11 +72,18 @@ def index_record(ei, rc, typ, r, do_index=True):
                     suffix = urldata.path.split("/")[-1]
                     r["data"][prefix + ":" + suffix] = r["data"][k]
                     d["flag_data_" + prefix + "_" + suffix + "_munge"] = True
+            if k in UNINDEXABLE_OBJECTS:
+                # inventing a new flag for each field we are truncating
+                new_flag = "_".join(["flag", "idigbio", k.replace(":","_").lower(), "removed"])
+                d[new_flag] = True
+                # truncate the troublesome object to prevent Elasticsearch mapper_parsing_exception
+                d[k] = {}
+                r["data"][k] = {}
 
         i["data"] = r["data"]
         i["indexData"] = d
 
-        if config.IDB_EXTRA_SERIOUS_DEBUG == 'yes': # dummy comment because github
+        if config.IDB_EXTRA_SERIOUS_DEBUG == 'yes':
             logger.debug("Index record: %s with approx. %s bytes of data.", i["uuid"], len(repr(i)))
             logger.debug("Data: %s", repr(i))
 


### PR DESCRIPTION
Elasticsearch does not allow field names containing dots.

Sample record:

```json
{
   "dwc:organismQuantity" : "1",
   "dwc:institutionCode" : "RBINS-Scientific Heritage",
   "dwc:scientificNameAuthorship" : "Stechow, 1919",
   "dwc:datasetID" : "be_rbins_darwin",
   "dcterms:rightsHolder" : "Royal Belgian Institute of Natural Sciences",
   "dwc:basisOfRecord" : "PreservedSpecimen",
   "dwc:genus" : "Plumularia Lamarck",
   "dcterms:type" : "PhysicalObject",
   "dwc:otherCatalogNumbers" : "urn:catalog:RBINS:IG:27838",
   "dwc:family" : "Plumulariidae",
   "dwc:collectionCode" : "urn:catalog:RBINS:hyd",
   "dwc:verbatimLocality" : "Seychelles",
   "dwc:taxonomicStatus" : "valid",
   "dcterms:license" : "https://creativecommons.org/licenses/by-nc/4.0",
   "obis:ExtendedMeasurementOrFact" : [
      {
         "coreid" : "https://darwin.naturalsciences.be/uri/object/000a81cd-60f0-4d13-bf02-b0d4fe1938a2",
         "http://rs.iobis.org/obis/terms/measurementTypeID" : "vocab.nerc.ac.uk/collection/P01/current/OCOUNT01",
         "dwc:occurrenceID" : "https://darwin.naturalsciences.be/uri/object/000a81cd-60f0-4d13-bf02-b0d4fe1938a2",
         "dwc:measurementValue" : "1",
         "dwc:measurementType" : "count",
         "dwc:measurementUnit" : "Number of individuals in container" 
      },
      {
         "dwc:measurementType" : "lifestage",
         "dwc:measurementValue" : "unknown",
         "dwc:occurrenceID" : "https://darwin.naturalsciences.be/uri/object/000a81cd-60f0-4d13-bf02-b0d4fe1938a2",
         "http://rs.iobis.org/obis/terms/measurementTypeID" : "vocab.nerc.ac.uk/collection/P01/current/LSTAGE01",
         "coreid" : "https://darwin.naturalsciences.be/uri/object/000a81cd-60f0-4d13-bf02-b0d4fe1938a2",
         "http://rs.iobis.org/obis/terms/measurementValueID" : "http://vocab.nerc.ac.uk/collection/S11/current/S1152" 
      },
      {
         "dwc:measurementType" : "sex",
         "dwc:measurementValue" : "unknown",
         "dwc:occurrenceID" : "https://darwin.naturalsciences.be/uri/object/000a81cd-60f0-4d13-bf02-b0d4fe1938a2",
         "coreid" : "https://darwin.naturalsciences.be/uri/object/000a81cd-60f0-4d13-bf02-b0d4fe1938a2",
         "http://rs.iobis.org/obis/terms/measurementTypeID" : "vocab.nerc.ac.uk/collection/P01/current/ENTSEX01",
         "http://rs.iobis.org/obis/terms/measurementValueID" : "http://vocab.nerc.ac.uk/collection/S10/current/S104" 
      }
   ],
   "dwc:taxonID" : "https://www.gbif.org/species/2266954",
   "dwc:phylum" : "Cnidaria Hatschek, 1888",
   "dwc:occurrenceStatus" : "present",
   "dcterms:language" : "en",
   "dwc:scientificNameID" : "urn:lsid:marinespecies.org:taxname:285311",
   "dwc:occurrenceID" : "https://darwin.naturalsciences.be/uri/object/000a81cd-60f0-4d13-bf02-b0d4fe1938a2",
   "dwc:sex" : "unknown",
   "dwc:kingdom" : "Animalia",
   "dwc:class" : "Hydrozoa Owen, 1843",
   "dwc:fieldNumber" : "27838",
   "dwc:nomenclaturalCode" : "ICZN",
   "dwc:identifiedBy" : "Bouillon Jean (Prof.)",
   "dwc:scientificName" : "Plumularia warreni Stechow, 1919",
   "dwc:specificEpithet" : "warreni",
   "dwc:recordedBy" : "Bouillon Jean (Prof.)",
   "dwc:preparations" : "container type: specimen jar; preservation method: alcohol",
   "dwc:ownerInstitutionCode" : "RBINS",
   "dwc:eventDate" : "1966",
   "dwc:taxonRank" : "species",
   "dwc:typeStatus" : "specimen",
   "dwc:disposition" : "Present",
   "dwc:organismQuantityType" : "SpecimensInContainer",
   "dwc:lifeStage" : "unknown",
   "dwc:catalogNumber" : "INV.41866",
   "dwc:institutionID" : "https://www.wikidata.org/wiki/Q222297",
   "dwc:parentNameUsage" : "Plumularia Lamarck",
   "id" : "https://darwin.naturalsciences.be/uri/object/000a81cd-60f0-4d13-bf02-b0d4fe1938a2",
   "dwc:collectionID" : "http://collections.naturalsciences.be/19",
   "dwc:datasetName" : "Royal Belgian Institute of Natural Sciences Collection",
   "dwc:order" : "Hydroida Johnston, 1836" 
}
```

The problematic field name is `http://rs.iobis.org/obis/terms/measurementTypeID`.

For now we will truncate these objects at the top level.  In this case, `obis:ExtendedMeasurementOrFact` will remain in place but the content will be replaced with an empty dict.

We will also add a DQ flag to indicate that we truncated the record.

The flag for  `obis:ExtendedMeasurementOrFact` is generated to be `flag_idigbio_obis_extendedmeasurementorfact_truncated`.