### PR TITLE
change systemd units to work with non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ The ingestion services are configured to run as a user named `idigbio-ingestion`
 
 1. Install the `virtualenv` system package (and the Dependencies listed above if not already installed):
 
-   apt install virtualenv
+```
+apt install virtualenv
 
-   apt install python-dev libblas-dev liblapack-dev \
-      libatlas-base-dev gfortran libgdal-dev libpq-dev libgeos-c1v5 \
-      libsystemd-dev \
-      libxml2 libxslt1-dev ffmpeg fonts-dejavu-core libfreetype6-dev python-systemd
+apt install python-dev libblas-dev liblapack-dev \
+    libatlas-base-dev gfortran libgdal-dev libpq-dev libgeos-c1v5 \
+    libsystemd-dev \
+    libxml2 libxslt1-dev ffmpeg fonts-dejavu-core libfreetype6-dev python-systemd
+```
 
 2. Become the idigbio-ingestion user (via `su - idigbio-ingestion`), and clone this repo:
 
@@ -81,21 +83,15 @@ The ingestion services are configured to run as a user named `idigbio-ingestion`
 
 3. Set up the python virtual environment:
 
-
-    cd idb-backend
-
-    virtualenv -p python2.7 .venv
-
-    source .venv/bin/activate
-
-    python --version
-
-    pip --no-cache-dir install -e .
-
-    pip --no-cache-dir install -r requirements.txt
-
-    deactivate
-
+```
+cd idb-backend
+virtualenv -p python2.7 .venv
+source .venv/bin/activate
+python --version
+pip --no-cache-dir install -e .
+pip --no-cache-dir install -r requirements.txt
+deactivate
+```
 
 From this point, software inside the virtual environment (including python, pip, py.test, etc.) can be run by referencing the path to the binary inside the environment.
 
@@ -108,6 +104,8 @@ Place a valid `idigbio.json` in the `idigbio-ingestion` home directory.
 
 5. Setup the ingestion-related services, by linking systemd to the unit files included in the repo.
 
+*Note:* All of the following `systemctl` commands will need to be run by root or a user with sudo permission. 
+
     systemctl link /home/idigbio-ingestion/etc/systemd/system/idigbio-ingestion-*
 
 6. Enable the services as needed.
@@ -116,8 +114,27 @@ Place a valid `idigbio.json` in the `idigbio-ingestion` home directory.
 
     systemctl enable <service>
 
+The recommended services to enable and start:
 
-To update the code used by the services, change to the `idigbio-ingestion` user and `git pull`.  Restart services as needed.
+    idigbio-ingestion-update-publisher-recordset.timer
+
+    idigbio-ingestion-mediaing-get-media.service
+
+    idigbio-ingestion-derivatives.timer
+
+
+The timers kick off "oneshot" services that run once and complete and need to be triggered again so the timer handles this.
+
+The get-media service (aka the "fetcher") has its own built-in loop to run continuously.
+
+
+7. To update the code used by the services, change to the `idigbio-ingestion` user's checkout of this repo and `git pull`.   Then as root or a user with sudo permissions, execute:
+
+    systemctl daemon-reload
+
+and restart the relevant services with 
+
+    systemctl restart <service>
 
 ### Docker Image
 

--- a/README.md
+++ b/README.md
@@ -51,21 +51,73 @@ The available extra components are:
 
 ### Persistent Services
 
-To setup all persistent services and timers (aka tasks and crons):
+#### data api
 
-    systemctl link $PWD/etc/systemd/system/*
+The data API is currently the only way external to the database to view previous versions of resources (e.g. v1 of a record that has been updated multiple times).
 
-    systemctl enable --now $(grep -l Install $PWD/etc/systemd/system/*)
+The service unit file is `idigbio-data-api.service`.
 
-To setup only a subset, for example the "ingestion" services:
+#### stats aggregator
 
-    systemctl link $PWD/etc/systemd/system/idigbio-ingestion-*
+Stats of various type are aggregated by this service.  More info is available in [the stats readme](stats/readme.md).
 
-And then enable the servivces as needed.
+#### data ingestion services
 
-    systemctl list-units idigbio-*
+The ingestion services are configured to run as a user named `idigbio-ingestion`.  If this user does not exist on the system it must be created.  It is suggested to use a home directory `/home/idigbio-ingestion`.
+
+
+1. Install the `virtualenv` system package (and the Dependencies listed above if not already installed):
+
+   apt install virtualenv
+
+   apt install python-dev libblas-dev liblapack-dev \
+      libatlas-base-dev gfortran libgdal-dev libpq-dev libgeos-c1v5 \
+      libsystemd-dev \
+      libxml2 libxslt1-dev ffmpeg fonts-dejavu-core libfreetype6-dev python-systemd
+
+2. Become the idigbio-ingestion user (via `su - idigbio-ingestion`), and clone this repo:
+
+    git clone https://github.com/iDigBio/idb-backend.git
+
+3. Set up the python virtual environment:
+
+
+    cd idb-backend
+
+    virtualenv -p python2.7 .venv
+
+    source .venv/bin/activate
+
+    python --version
+
+    pip --no-cache-dir install -e .
+
+    pip --no-cache-dir install -r requirements.txt
+
+    deactivate
+
+
+From this point, software inside the virtual environment (including python, pip, py.test, etc.) can be run by referencing the path to the binary inside the environment.
+
+    ./venv/bin/pip freeze
+
+4. configure idb-backend config
+
+Place a valid `idigbio.json` in the `idigbio-ingestion` home directory.
+
+
+5. Setup the ingestion-related services, by linking systemd to the unit files included in the repo.
+
+    systemctl link /home/idigbio-ingestion/etc/systemd/system/idigbio-ingestion-*
+
+6. Enable the services as needed.
+
+    systemctl list-units idigbio-ingestion-*
 
     systemctl enable <service>
+
+
+To update the code used by the services, change to the `idigbio-ingestion` user and `git pull`.  Restart services as needed.
 
 ### Docker Image
 

--- a/etc/systemd/system/idigbio-ingestion-derivatives.service
+++ b/etc/systemd/system/idigbio-ingestion-derivatives.service
@@ -5,4 +5,8 @@ Description=iDigBio mediaing derivatives generation
 Type=oneshot
 Environment=LANG=en_US.UTF-8
 User=idigbio-ingestion
-ExecStart=/usr/local/bin/idigbio-ingestion -v --journal derivatives --procs 2
+Group=idigbio-ingestion
+Environment=IDB_STORAGE_HOST=s2.idigbio.org
+PassEnvironment=IDB_STORAGE_HOST
+WorkingDirectory=/home/idigbio-ingestion/work_dir
+ExecStart=/home/idigbio-ingestion/idb-backend/venv/bin/idigbio-ingestion -v --journal derivatives --procs 2

--- a/etc/systemd/system/idigbio-ingestion-derivatives.service
+++ b/etc/systemd/system/idigbio-ingestion-derivatives.service
@@ -4,4 +4,5 @@ Description=iDigBio mediaing derivatives generation
 [Service]
 Type=oneshot
 Environment=LANG=en_US.UTF-8
+User=idigbio-ingestion
 ExecStart=/usr/local/bin/idigbio-ingestion -v --journal derivatives --procs 2

--- a/etc/systemd/system/idigbio-ingestion-mediaing-get-media.service
+++ b/etc/systemd/system/idigbio-ingestion-mediaing-get-media.service
@@ -5,9 +5,11 @@ Description=iDigBio mediaing fetcher
 Type=simple
 Environment=LANG=en_US.UTF-8
 User=idigbio-ingestion
+Group=idigbio-ingestion
 Environment=IDB_STORAGE_HOST=s2.idigbio.org
 PassEnvironment=IDB_STORAGE_HOST
-ExecStart=/usr/local/bin/idigbio-ingestion \
+WorkingDirectory=/home/idigbio-ingestion/work_dir
+ExecStart=/home/idigbio-ingestion/idb-backend/venv/bin/idigbio-ingestion \
     -vv --journal \
     mediaing get-media --continuous
 

--- a/etc/systemd/system/idigbio-ingestion-mediaing-get-media.service
+++ b/etc/systemd/system/idigbio-ingestion-mediaing-get-media.service
@@ -4,6 +4,7 @@ Description=iDigBio mediaing fetcher
 [Service]
 Type=simple
 Environment=LANG=en_US.UTF-8
+User=idigbio-ingestion
 Environment=IDB_STORAGE_HOST=s2.idigbio.org
 PassEnvironment=IDB_STORAGE_HOST
 ExecStart=/usr/local/bin/idigbio-ingestion \

--- a/etc/systemd/system/idigbio-ingestion-mediaing-migrate.service
+++ b/etc/systemd/system/idigbio-ingestion-mediaing-migrate.service
@@ -1,4 +1,6 @@
 [Unit]
+# Is this still needed?  Once media appliance is no longer in use anywhere? - Dan
+
 Description="Runs the `idigbio-ingestion mediaing updatedb` daily task"
 
 [Service]

--- a/etc/systemd/system/idigbio-ingestion-mediaing-migrate.service
+++ b/etc/systemd/system/idigbio-ingestion-mediaing-migrate.service
@@ -4,6 +4,7 @@ Description="Runs the `idigbio-ingestion mediaing updatedb` daily task"
 [Service]
 Type=oneshot
 Environment=LANG=en_US.UTF-8
+User=idigbio-ingestion
 SyslogIdentifier=idb-ingest-media-migrate
 ExecStart=/usr/local/bin/idigbio-ingestion \
     --journal -vv mediaing migrate

--- a/etc/systemd/system/idigbio-ingestion-mediaing-updatedb.service
+++ b/etc/systemd/system/idigbio-ingestion-mediaing-updatedb.service
@@ -1,4 +1,7 @@
 [Unit]
+# I believe this is no longer needed.  We successfully ingested media without this service running.
+# I could be wrong though.  - Dan
+
 Description="Runs the `idigbio-ingestion mediaing updatedb` daily task"
 
 [Service]

--- a/etc/systemd/system/idigbio-ingestion-mediaing-updatedb.service
+++ b/etc/systemd/system/idigbio-ingestion-mediaing-updatedb.service
@@ -4,6 +4,7 @@ Description="Runs the `idigbio-ingestion mediaing updatedb` daily task"
 [Service]
 Type=oneshot
 Environment=LANG=en_US.UTF-8
+User=idigbio-ingestion
 ExecStart=/usr/local/bin/idigbio-ingestion \
     --journal -vv \
     mediaing updatedb --daily

--- a/etc/systemd/system/idigbio-ingestion-update-publisher-recordset.service
+++ b/etc/systemd/system/idigbio-ingestion-update-publisher-recordset.service
@@ -4,4 +4,5 @@ Description="Runs `idigbio-ingestion update-publisher-recordset`"
 [Service]
 Type=oneshot
 Environment=LANG=en_US.UTF-8
+User=idigbio-ingestion
 ExecStart=/usr/local/bin/idigbio-ingestion --journal -v update-publisher-recordset

--- a/etc/systemd/system/idigbio-ingestion-update-publisher-recordset.service
+++ b/etc/systemd/system/idigbio-ingestion-update-publisher-recordset.service
@@ -5,4 +5,8 @@ Description="Runs `idigbio-ingestion update-publisher-recordset`"
 Type=oneshot
 Environment=LANG=en_US.UTF-8
 User=idigbio-ingestion
-ExecStart=/usr/local/bin/idigbio-ingestion --journal -v update-publisher-recordset
+Group=idigbio-ingestion
+Environment=IDB_STORAGE_HOST=s2.idigbio.org
+PassEnvironment=IDB_STORAGE_HOST
+WorkingDirectory=/home/idigbio-ingestion/work_dir
+ExecStart=/home/idigbio-ingestion/idb-backend/venv/bin/idigbio-ingestion --journal -v update-publisher-recordset


### PR DESCRIPTION
Update docs and systemd unit files to enable services on the new workflow node with a non-root user.

Point the backend at the s2 blob storage gateways to avoid impacting user-facing storage gateways.