### PR TITLE
prevent raising Exception on bulk index errors and exceptions

### DIFF
--- a/idb/indexing/index_from_postgres.py
+++ b/idb/indexing/index_from_postgres.py
@@ -309,6 +309,7 @@ def consume(ei, rc, iter_func, no_index=False):
                 pass
         else:
             for ok, item in ei.bulk_index(index_record_tuples):
+                # Is there a way to try/except the iterator to prevent Exceptions from being fatal?
                 pass
         gc.collect()
 

--- a/idb/indexing/indexer.py
+++ b/idb/indexing/indexer.py
@@ -293,7 +293,12 @@ class ElasticSearchIndexer(object):
         Needs more info here.
         """
         return elasticsearch.helpers.streaming_bulk(
-            self.es, self.bulk_formater(tups), chunk_size=config.ES_INDEX_CHUNK_SIZE, max_chunk_bytes=1048576)
+            self.es,
+            self.bulk_formater(tups),
+            chunk_size=config.ES_INDEX_CHUNK_SIZE,
+            max_chunk_bytes=1048576,
+            raise_on_error=False,
+            raise_on_exception=False)
 
     def close(self):
         """


### PR DESCRIPTION
In this branch we turn off Elasticsearch `raise_on_error` and `raise_on_exception`.

This means legitimate errors/exceptions will also be passed over, but at this point this seems to be the way to work around exceptions triggered in Bulk index.

Consider adding these as CONFIG values prior to merging, or shortly after in a separate PR.