### PR TITLE
log errors during bulk indexing

### DIFF
--- a/idb/indexing/index_from_postgres.py
+++ b/idb/indexing/index_from_postgres.py
@@ -301,9 +301,14 @@ def consume(ei, rc, iter_func, no_index=False):
         else:
             for ok, item in ei.bulk_index(index_record_tuples):
                 # Is there a way to try/except the iterator to prevent Exceptions from being fatal?
-                pass
-        gc.collect()
-
+                # Let's try!
+                #
+                # pass
+                if not ok:
+                    logger.warning('Failed during bulk index index: {0} '.format(item))
+        # We should never need to call gc manually.  Can we drop this?  Especially
+        # since we no longer ever use continuous mode.
+        gc.collect() 
 
 def continuous_incremental(ei, rc, no_index=False):
     while True:


### PR DESCRIPTION
Now that we have stopped fatal abort on every indexing exception, we need to log the errors that actually occur.

This is working beautifully now.

Sample logline:

```
2021-11-13 12:24:17.042 WARNI idb.index_from_postgres჻ Failed during bulk index index: {u'index': {u'status': 400, u'_type': u'records', u'_id': u'026de0a3-def4-4d08-9db8-d6638ab8e8d3', u'error': {u'reason': u"Field name [https://symbiota.org/terms/recordEnteredBy] cannot contain '.'", u'type': u'mapper_parsing_exception'}, u'_index': u'idigbio-dan-test-1'}} 

```