### PR TITLE
pin `chardet` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
             'pydub==0.16.5',
             pillow_package,
             'lxml',
-            'chardet',
+            'chardet==3.0.4',
             'pyquery==1.2.17',
         ],
         'test': [


### PR DESCRIPTION
On some systems, pip gives the following when trying to install requirements:

    ERROR: pip's legacy dependency resolver does not consider dependency conflicts
    when selecting packages. This behaviour is the source of the following dependency
    conflicts.
    requests 2.20.0 requires chardet<3.1.0,>=3.0.2, but you'll have chardet 4.0.0 which is incompatible.

pin chardet to the version known to work in production: 3.0.4.