### PR TITLE
ALA new namespaces

### DIFF
--- a/idb/helpers/fieldnames.py
+++ b/idb/helpers/fieldnames.py
@@ -4,7 +4,7 @@ import string
 from collections import defaultdict
 
 '''
-The namespaces are ...
+Namespaces differentiate the sources of terms / definitions.
 '''
 
 namespaces = {
@@ -28,7 +28,11 @@ namespaces = {
     "http://ns.adobe.com/exif/1.0/": "exif",
     "http://purl.org/NET/aec/NET/aec/": "aec",
     "http://purl.org/NET/aec/": "aec",
-    "http://zooarchnet.org/dwc/terms/": "zan"
+    "http://zooarchnet.org/dwc/terms/": "zan",
+    "http://rs.ala.org.au/terms/1.0/": "ala",
+    "http://rs.tdwg.org/abcd/terms/": "abcd",
+    "http://hiscom.chah.org.au/hispid/terms/": "hispid",
+    "http://data.ggbn.org/schemas/ggbn/terms/": "ggbn"
 }
 
 namespaces_rev = {v:k for k, v in namespaces.items()}
@@ -40,7 +44,9 @@ namespaces_rev["aec"] = "http://purl.org/NET/aec/"
 namespaces_rev["Iptc4xmpExt"] = "http://iptc.org/std/Iptc4xmpExt/2008-02-29/"
 
 '''
-types map the namespace URI to a Compact URI / CURIE
+This "types" data structure holds all of the known Extensions.
+The namespace URI is mapped to a Compact URI / CURIE.
+All extensions used in any darwin core archive that we process must exist here.
 '''
 types = {
     "http://purl.org/NET/aec/associatedTaxa": {"shortname": "aec:associatedTaxa"},
@@ -66,7 +72,8 @@ types = {
 }
 
 '''
-The translate_dict is used to...
+The translate_dict is used by get_canonical_name() to map "similar" field names to the canonical
+name for the field.
 '''
 translate_dict = {
     "ac:accessURI": ["ac:accessURI", "dwc:Multimedia"],

--- a/idb/helpers/fieldnames.py
+++ b/idb/helpers/fieldnames.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 
 '''
 Namespaces differentiate the sources of terms / definitions.
+When we encounter a new term from a new namespace, the namespace should be
+added here.
 '''
 
 namespaces = {
@@ -45,7 +47,7 @@ namespaces_rev["Iptc4xmpExt"] = "http://iptc.org/std/Iptc4xmpExt/2008-02-29/"
 
 '''
 This "types" data structure holds all of the known Extensions.
-The namespace URI is mapped to a Compact URI / CURIE.
+The term URI is mapped to a Compact URI / CURIE.
 All extensions used in any darwin core archive that we process must exist here.
 '''
 types = {

--- a/idigbio_ingestion/db_check.py
+++ b/idigbio_ingestion/db_check.py
@@ -570,9 +570,6 @@ def metadataToSummaryJSON(rsid, metadata, writeFile=True, doStats=True):
     summary["duplicate_occurence_count"] = duplicate_record_count
     summary["dublicate_occurence_ids"] = duplicate_id_count
 
-    if doStats:
-        stats.index(doc_type='digest', body=summary)
-
     if writeFile:
         with AtomicFile(rsid + ".summary.json", "wb") as jf:
             json.dump(summary, jf, indent=2)
@@ -580,8 +577,11 @@ def metadataToSummaryJSON(rsid, metadata, writeFile=True, doStats=True):
         with AtomicFile(rsid + ".metadata.json", "wb") as jf:
             json.dump(metadata, jf, indent=2)
             jf.write(os.linesep)
-    else:
-        return summary
+    
+    if doStats:
+        stats.index(doc_type='digest', body=summary)
+    
+    return summary
 
 
 def main(rsid, ingest=False):

--- a/idigbio_ingestion/lib/dwca.py
+++ b/idigbio_ingestion/lib/dwca.py
@@ -187,11 +187,26 @@ class DwcaRecordFile(DelimitedFile):
             # drop any extra quote characters
             term = fld['#term'].replace("\"","")
 
-            # map xmp namespaces into short code form (xxx:fieldName), longest namespaces first
+            # Map fieldnames that contain a namespace to a CURIE form that includes the
+            # shortened namespace alias and the term name (namespace:term).
+            # e.g.   dwc:basisOfRecord
+            # Sort by longest namespaces first
+            ns_found = False
             for ns in sorted(namespaces.keys(),key=lambda x: len(x), reverse=True):
                 if term.startswith(ns):
+                    ns_found = True
                     term = term.replace(ns,namespaces[ns]+":")
                     break
+            
+            if not ns_found:
+                self.logger.warning("Term '{0}' does not belong to a known namespace.".format(term))
+                if "." in term:
+                    # Due to downstream limitations of Elasticsearch, do not allow fieldnames containing dots.
+                    # If we encounter a new field containing dots it usually means the namespace
+                    # needs to be added to fieldnames.py.
+                    self.logger.fatal("Term '{0}' contains a dot '.' which is not allowed in field names.".format(term))
+                    raise Exception("Term '{0}' contains a dot '.' which is not allowed in field names.".format(term))
+
             self.logger.debug("Using term = '{0}'".format(term))
             if '#index' in fld:
                 if int(fld['#index']) not in fields:


### PR DESCRIPTION
Support new term sources in data published by ALA.

Trigger fatal error when dotted fieldnames are detected
    
While processing darwin core archives, we normally map dotted term
references to a CURIE.
    
"http://rs.tdwg.org/dwc/terms/occurrenceID" as specified in meta.xml
becomes "dwc:dwc:occurrenceID" when we store the field in postgres.
    
In situations where new terms are introduced by the community from
previously-unknown namespaces, the code was previously defaulting
to using the field-name as-provided (including the dots "."). This
had downstream effects during Indexing because Elasticsearch no
longer supports dots in fieldnames.
    
The code changes here will prevent field names with dots from
being created in the database and should prevent the negative
downstream effect during indexing.
