### PR TITLE
Revert "add logging when worker connects to redis"

### DIFF
--- a/idigbio_workers/__init__.py
+++ b/idigbio_workers/__init__.py
@@ -4,10 +4,8 @@ import socket
 from celery import Celery
 from celery.result import AsyncResult  # noqa
 from idb import config, __version__
-from idb.helpers.logging import idblogger
-from idb.helpers.memoize import memoized
 
-logger = idblogger.getChild('worker')
+from idb.helpers.memoize import memoized
 
 env = config.ENV
 
@@ -28,9 +26,7 @@ def get_redis_connection_params():
 
 def get_redis_conn():
     import redis
-    redis_conn_params = get_redis_connection_params()
-    logger.info('Connecting to redis with the following params: {0}'.format(redis_conn_params))
-    return redis.StrictRedis(**redis_conn_params)
+    return redis.StrictRedis(**get_redis_connection_params())
 
 
 @app.task()


### PR DESCRIPTION
Figured out how to test (`celery worker ...`).  

After further iteration I was still unable to get a code change that actually got additional loglines into the Celery logging output.

Seems better to revert iDigBio/idb-backend#207

Running with `celery worker --app=idigbio_workers -l INFO` will include the desired info in Celery's output.

