### PR TITLE
add "mappings" command to idb index to only put mappings

### DIFF
--- a/idb/indexing/__init__.py
+++ b/idb/indexing/__init__.py
@@ -186,3 +186,17 @@ def check(params):
     for k in params:
         params[k] = params[k]()
     resume(also_delete=True, **params)
+
+
+@cli.command(help="PUT mappings only and then exit")
+@click.pass_obj
+@fnlogged
+def mappings(params):
+    """
+    We currently put the ES mappings whenever we initialize the connection to Elasticsearch.
+    This option will not attempt any actual indexing but will put the mappings into the index.
+    """
+    for k in params:
+        params[k] = params[k]()
+    from .index_from_postgres import mappings_only
+    mappings_only(**params)

--- a/idb/indexing/index_from_postgres.py
+++ b/idb/indexing/index_from_postgres.py
@@ -286,6 +286,9 @@ def uuids(ei, rc, uuid_l, no_index=False, children=False):
     consume(ei, rc, f, no_index=no_index)
     ei.optimize()
 
+def mappings_only(ei):
+    ei.optimze()
+
 def consume(ei, rc, iter_func, no_index=False):
     for typ in ei.types:
         # Construct a version of index record that can be just called with the


### PR DESCRIPTION
```
idb index mappings --help
Usage: idb index mappings [OPTIONS]

  PUT mappings only and then exit
```