### PR TITLE
Updating .devcontainer for VS Code Docker development

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.gitignore
+
+idigbio*.json
+
+**/*.pyc
+etc/
+cover/
+.coverage
+*.egg-info/
+.cache/
+.dir-locals.el
+Dockerfile
+.travis.yml
+.devcontainer

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,22 @@
-FROM idigbio/docker-library.base-idb-backend:latest
+FROM python:2.7
 
-RUN apt update && apt install -y \
-    postgresql-client
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+        gfortran \
+        libatlas-base-dev \
+        ffmpeg \
+        libblas-dev \
+        libgdal-dev \
+        liblapack-dev \
+        libpq-dev \
+        bsdmainutils; \
+    rm -rf /var/tmp/* /tmp/* /var/lib/apt/lists/*
 
-# probably need other things too at least until we get local dev env setup
+RUN /usr/local/bin/python -m pip install --upgrade pip
+
+# Install the list of packages in setup.py here so that this
+# image layer can be cached.  It takes a long time to build and
+# install these.
+COPY ./requirements.txt /opt/idb-backend/requirements.txt
+WORKDIR /opt/idb-backend
+RUN pip --no-cache-dir install -r requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
-// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/docker-existing-dockerfile
 {
-	"name": "devcontainer Dockerfile",
+	// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+	// https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/docker-existing-dockerfile
+
+	"name": "iDigBio Docker Development",
 
 	// Sets the run context to one level up instead of the .devcontainer folder.
 	//   // This context thing doesn't seem to work, can't open in container. - Dan
@@ -9,45 +10,39 @@
 
 	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 	//"dockerFile": "Dockerfile",
-	"dockerComposeFile": "docker-compose.yml",
+	"dockerComposeFile": "docker-compose-base.yml",
 	"service": "idb-backend",
+	"workspaceFolder": "/opt/idb-backend",
+	"shutdownAction": "stopCompose",
+
 	// We have an image!
 	//  But we want to customize it a little, so use the Dockerfile intead.
 	// "image" : "idigbio/docker-library.base-idb-backend:latest",
 	
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
-		// "python.pythonPath": "/usr/local/bin/python",
-		"python.linting.enabled": true,
-		// "python.linting.pylintEnabled": true,
-		// "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-		// "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-		// "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-		// "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-		// "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-		// "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-		// "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-		// "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-		// "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-		// "python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
-	},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-python.python"
-	],
-
+	"customizations": {
+		"vscode": {
+			"settings": { 
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"python.linting.enabled": true
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance"
+			]
+		}
+	}
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install -r requirements.txt",
+	//"postCreateCommand": "pip install -r requirements.txt",
 
 	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker.
 	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
 
 	// This will mount the .devcontainer/idigbio.json into the workspace at the top level directory "." and at "~/" to ensure
 	// the local dev idigbio.json config values are used inside the dev container.  Bind mount paths must be absolute.
-	"mounts": ["source=${localWorkspaceFolder}/.devcontainer/idigbio.json,target=/workspaces/idb-backend/idigbio.json,type=bind",
-		"source=${localWorkspaceFolder}/.devcontainer/idigbio.json,target=/root/idigbio.json,type=bind"]
+	//"mounts": ["source=${localWorkspaceFolder}/.devcontainer/idigbio.json,target=/workspaces/idb-backend/idigbio.json,type=bind",
+	//	"source=${localWorkspaceFolder}/.devcontainer/idigbio.json,target=/root/idigbio.json,type=bind"]
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"

--- a/.devcontainer/docker-compose-base.yml
+++ b/.devcontainer/docker-compose-base.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  idb-backend:
+    image: idb-base
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash -c "tail -f /dev/null"
+    environment:
+      ENV: dev
+    volumes:
+      - ..:/opt/idb-backend
+      - ./idigbio.json:/etc/idigbio/idigbio.json

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,47 @@
+pillow>=3.4,<=5.1.1
+pyquery==1.2.17
+psycopg2-binary>=2.8.3
+redis>=2.9.1, <3.0.0
+python-dateutil>=2.2, <3.0
+udatetime>=0.0.13
+elasticsearch>=5, <6
+pyproj>=1.9.3
+pytz>=2016.10
+requests==2.20.0
+urllib3>=1.21.1<1.25
+pycrypto
+flask>=0.11.0, <1.0.0
+Flask-UUID
+Flask-CORS
+coverage
+numpy
+scipy
+gevent>=1.1.0, <1.2.0
+gipc>=0.6.0, <0.7.0
+unicodecsv>=0.14.1, < 0.15.0
+shapely
+celery[redis]>=4.0, <4.3
+boto>=2.39.0, <3.0.0
+fiona
+python-magic>=0.4.11, <=0.5.0
+feedparser>=5.2.0
+click>=6.3, <7.0
+atomicfile==1.0
+enum34>=1.1.6, <1.2.0
+path.py>=10.0.0, <11
+wsgi-request-logger>=0.4.6
+jsonlines>=1.1.3
+pathlib
+
+# The following are for ingest
+pydub==0.16.5
+lxml
+chardet==3.0.4
+pyquery==1.2.17
+
+# The following are for testing
+pytest>=3.0
+pytest-cov
+pytest-flask
+pytest-mock==1.13.0
+fakeredis

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -5,7 +5,7 @@ redis>=2.9.1, <3.0.0
 python-dateutil>=2.2, <3.0
 udatetime>=0.0.13
 elasticsearch>=5, <6
-pyproj>=1.9.3
+pyproj>=1.9.3, <2
 pytz>=2016.10
 requests==2.20.0
 urllib3>=1.21.1<1.25


### PR DESCRIPTION
These changes made the VS Code "open in container" feature work for me.  Rather than reference the container development Dockerfile (i.e. the one inside .devcontainer) directly in .devcontainer.json, a new docker-compose-base.yml file is referenced which mounts the project directory.  The old docker-compose file, which has services for Postgres and MinIO for running the tests, is unchanged.  This is working for me with VS Code on Ubuntu 22 and on an M1 Macbook.

The Dockerfile also has changes: it starts from the python:2.7 image rather than the idigbio image.  This change is left over from experimenting with Py4J and I am not sure it is required to make the "open in container" feature work.