### PR TITLE
allow dates back to the 1500s

### DIFF
--- a/idb/helpers/conversions.py
+++ b/idb/helpers/conversions.py
@@ -223,7 +223,7 @@ for t in fields:
 
 
 def checkBounds(x):
-    lowerBound = datetime.datetime(1700, 1, 2, tzinfo=pytz.utc)
+    lowerBound = datetime.datetime(1500, 1, 2, tzinfo=pytz.utc)
     upperBound = datetime.datetime.now(pytz.utc)
     if isinstance(x, datetime.datetime):
         return x < lowerBound or x > upperBound


### PR DESCRIPTION
As reported in https://github.com/iDigBio/idb-backend/issues/229 the oldest natural history records actually date back to the 1500s rather than 1700.

I have confirmed there are some digitized records in GBIF from the 1600s.

Moving our zero date back a few hundred years.