### PR TITLE
Setting up Py4J record correction option in indexing

### DIFF
--- a/idb/corrections/gbif_record_corrector.py
+++ b/idb/corrections/gbif_record_corrector.py
@@ -1,0 +1,24 @@
+import json
+from py4j.java_gateway import JavaGateway
+
+class GbifJavaRecordCorrector(object):
+
+    def __init__(self):
+        self.gateway = JavaGateway()
+
+        # Find out right away if the Py4J gateway isn't running.
+        try:
+            jvm = self.gateway.jvm
+            print("JVM started: JRE version " + jvm.System.getProperty("jvm.version"))
+        except:
+            print("Error connecting to Py4J gateway, is it running?")
+            raise
+    
+    def correct_record(self, record_obj):
+        record_str = json.dumps(record_obj)
+        corrected_record_str = self.gateway.entry_point.correctRecord(record_str)
+        corrected_obj = json.loads(corrected_record_str)
+
+        # mmk: the second returned value is ignored, but needs to be present;
+        # it is meant to contain the keys for the values that were changed
+        return corrected_obj, dict()

--- a/idb/indexing/__init__.py
+++ b/idb/indexing/__init__.py
@@ -25,14 +25,18 @@ from idb.helpers.logging import fnlogged
                   'publishers', 'recordsets', 'mediarecords', 'records']),
               multiple=True)
 @click.option('--indexname')
+@click.option('--gbif/--no-gbif',
+              default=False,
+              help="Use GBIF Java record correction (instead of Python)")
 @click.pass_context
 @fnlogged
-def cli(ctx, index, corrections, types, indexname):
+def cli(ctx, index, corrections, types, indexname, gbif):
     from idb.helpers.logging import idblogger
     logger = idblogger.getChild('indexing')
     from idb import config
     from .indexer import ElasticSearchIndexer
     from idb.corrections.record_corrector import RecordCorrector
+    from idb.corrections.gbif_java_record_corrector import GbifJavaRecordCorrector
 
     if not types:
         types = config.config["elasticsearch"]["types"]
@@ -66,7 +70,7 @@ def cli(ctx, index, corrections, types, indexname):
     # function
     ctx.obj = {
         'ei': lambda: ElasticSearchIndexer(indexname, types, serverlist=serverlist),
-        'rc': lambda: RecordCorrector(reload=corrections),
+        'rc': lambda: GbifJavaRecordCorrector() if gbif else RecordCorrector(reload=corrections),
         'no_index': lambda: not index
     }
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         'path.py>=10.0.0, <11',
         'wsgi-request-logger>=0.4.6',
         'jsonlines>=1.1.3',
+        'py4j==0.10.9.7',
     ],
     extras_require={
         'ingestion': [


### PR DESCRIPTION
I've updated setup.py to import the Python-side Py4J library, added a "--gbif" flag option to the indexing command, and included a Python class in idb/corrections/gbif_record_corrector.py to serve as a stub for doing Java record correction.  If a Py4J gateway server is not running on the indexing host, it will error out with a message and a stack trace.  Indexing will default to the normal idb-backend record correction.