### PR TITLE
restrict arctos domain

### DIFF
--- a/idigbio_ingestion/mediaing/__init__.py
+++ b/idigbio_ingestion/mediaing/__init__.py
@@ -8,7 +8,8 @@ IGNORE_PREFIXES = [
     "https://api.idigbio.org/v2/media/",
     "http://api.idigbio.org/v2/media/",
     "http://www.tropicos.org/",
-    "http://n2t.net/ark:/65665/" # Smithsonian
+    "http://n2t.net/ark:/65665/", # Smithsonian
+    "http://arctos.database.museum/"
 ]
 
 


### PR DESCRIPTION
This prevents fetching from the Arctos domain for mediang when it is run. 