### PR TITLE
updates for neherbaria rss and mediaing

### DIFF
--- a/idigbio_ingestion/mediaing/cli.py
+++ b/idigbio_ingestion/mediaing/cli.py
@@ -42,14 +42,16 @@ def mediaing_get_media(mediaing_params, last_check_interval=None, continuous=Fal
 @mediaing.command(name="updatedb", help="Update the DB with new URLs")
 @click.option("--daily/--no-daily", default=False,
               help="Run in daily mode: only search for mediarecords in the last day.")
+@click.option("--since", default=None,
+              help="update since specified date")
 @click.pass_obj
 @fnlogged
-def mediaing_updatedb(mediaing_params, daily):
+def mediaing_updatedb(mediaing_params, daily, since):
     from idigbio_ingestion.mediaing import updatedb
     if daily:
-        updatedb.daily(prefix=mediaing_params['prefix'])
+        updatedb.daily(prefix=mediaing_params['prefix'],since=since)
     else:
-        updatedb.updatedb(prefix=mediaing_params['prefix'])
+        updatedb.updatedb(prefix=mediaing_params['prefix'],since=since)
 
 
 @cli.command(help="Generate derivatives in the specified buckets."

--- a/idigbio_ingestion/update_publisher_recordset.py
+++ b/idigbio_ingestion/update_publisher_recordset.py
@@ -159,6 +159,7 @@ def update_db_from_rss():
         logger.debug("Gathering existing recordsets...")
         for row in db.fetchall("SELECT * FROM recordsets"):
             recordsets[row["id"]] = row
+            row["file_link"] = row["file_link"].encode('utf-8').strip()
             file_links[row["file_link"]] = row["id"]
             for recordid in row["recordids"]:
                 logger.debug("id | recordid | file_link : '{0}' | '{1}' | '{2}'".format(
@@ -211,6 +212,12 @@ def _do_rss_entry(entry, portal_url, db, recordsets, existing_recordsets, pub_uu
     file_links : dict
         dict of existing known file_links with associated DB ids
     """
+    for k in entry:
+        if k == "link":
+            entry[k] = entry[k].encode('utf-8').strip()
+        elif k == "links":
+            if entry[k][0] is not None:
+                entry[k][0] = [v.encode('utf-8').strip() for v in entry[k][0]]
 
     logger.debug("Dump of this feed entry: '{0}'".format(entry))
 

--- a/scripts/rss-feed-dump-for-humans.py
+++ b/scripts/rss-feed-dump-for-humans.py
@@ -82,10 +82,10 @@ for entry in feed.entries:
     # However, the id is embedded in the middle of the id url so human can pluck it out if needed.
 
 
-    print ("title:        ", get_title(entry))
-    print ("published:    ", get_pubDate(entry))
-    print ("id:           ", get_id(entry))
-    print ("dataset link: ", get_dataset_link(entry))
-    print ("eml link:     ", get_eml_link(entry))
+    print ("title:        ", get_title(entry).encode('utf-8').strip())
+    print ("published:    ", get_pubDate(entry).encode('utf-8').strip())
+    print ("id:           ", get_id(entry).encode('utf-8').strip())
+    print ("dataset link: ", get_dataset_link(entry).encode('utf-8').strip())
+    print ("eml link:     ", get_eml_link(entry).encode('utf-8').strip())
     print (hr)
 


### PR DESCRIPTION
This updates the RSS script so that we may use it against RSS feeds which were not able to be viewed before due to UTF-8 encoding errors and changes update_publisher_recordset so that only the "link" field is formatted with UTF-8. It is a good place to start if we need any modifications for problematic RSS feeds. Currently, if any other fields are not valid UTF-8  they are not changed. MediaING process has been updated to accept a date range. So far this has proven to work with Neherbaria and will also be necessary to perform regular updates via ingestion without having to run it against the entire database or just for a 24 hour period.